### PR TITLE
Fix bug on members filter in documents

### DIFF
--- a/common/filter-mapper.js
+++ b/common/filter-mapper.js
@@ -294,14 +294,10 @@ const mapWhereFilter = (where, model) => {
     } else if (where.or) {
       break;
     } else {
-      scicatWhere.or = [
-        Object.assign(
-          ...Object.keys(where).map((key) => ({
-            creator: where[key],
-            authors: where[key],
-          }))
-        ),
-      ];
+      scicatWhere.or = Object.values(where).reduce(
+        (value, it) => value.concat({ creator: it }, { authors: it }),
+        []
+      );
     }
     break;
   }


### PR DESCRIPTION
when adding a filter on members as described here
https://github.com/panosc-eu/search-api/blob/master/doc/document-example-queries.md#filter,
query returns empty, because of a wrong formatting. Fixing this bug

## Description

Test for the specific fix has not been added, as this is more an integration test and currently the search api does not implement any of this sort

## Motivation

bug fix. Format before the bug fix: `{"where":{"or":[{"creator":"xxx", "authors":"xxx"}]}}`
After the bug fix: `{"where":{"or":[{"creator":"xxx"},{"authors":"xxx"}]}}`

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
