### PR TITLE
Add v and u mapping ti parameter v and u 

### DIFF
--- a/common/filter-mapper.js
+++ b/common/filter-mapper.js
@@ -352,7 +352,12 @@ const mapWhereFilter = (where, model) => {
             }
           } else {
             scicatWhere.and.push({
-              [`scientificMetadata.${name}.value`]: value,
+              "or": [{
+                [`scientificMetadata.${name}.value`]: value
+              },
+              {
+                [`scientificMetadata.${name}.v`]: value
+              }]
             });
           }
         } else {
@@ -421,7 +426,14 @@ const mapWhereFilter = (where, model) => {
                 });
               }
             } else {
-              return { [`scientificMetadata.${name}.value`]: value };
+              filter.and.push({
+                "or": [{
+                  [`scientificMetadata.${name}.value`]: value
+                },
+                {
+                  [`scientificMetadata.${name}.v`]: value
+                }]
+              });
             }
             return filter;
           } else {

--- a/common/response-mapper.js
+++ b/common/response-mapper.js
@@ -240,8 +240,8 @@ exports.parameters = (scientificMetadata, filter) => {
   return Object.keys(scientificMetadata).map((key) => {
     if (key === parameter.name) {
       const { value, unit } = utils.convertToUnit(
-        scientificMetadata[key].value,
-        scientificMetadata[key].unit,
+        scientificMetadata[key].valueSI,
+        scientificMetadata[key].unitSI,
         parameter.unit
       );
       return {
@@ -252,8 +252,8 @@ exports.parameters = (scientificMetadata, filter) => {
     } else {
       return {
         name: key,
-        value: scientificMetadata[key].value,
-        unit: scientificMetadata[key].unit,
+        value: scientificMetadata[key].value || scientificMetadata[key].v,
+        unit: scientificMetadata[key].unit || scientificMetadata[key].u,
       };
     }
   });

--- a/test/dataset.test.js
+++ b/test/dataset.test.js
@@ -93,135 +93,172 @@ describe("Dataset", () => {
       });
     });
 
-    context(
-      "where parameters has a photon energy in the range 880-990 eV",
-      () => {
-        it("should return en array of datasets matching the parameter", (done) => {
-          sandbox
-            .stub(ScicatDatasetService.prototype, "find")
-            .resolves(mockStubs.dataset.find.photonEnergyFilter);
+    const renameKeys = (ds, init = {}, nameMap = { value: "v", unit: "u" }) =>
+      Object.keys(ds).reduce((o, k) => 
+        (
+          typeof ds[k] === "object" && ds[k] !== null ?
+            (o[nameMap[k] || k] = {}, renameKeys(ds[k], o[nameMap[k] || k]))
+            : o[nameMap[k] || k] = ds[k],
+          o
+        ),
+      init);
+    const testsPhotonEnergy = [
+      {
+        args: mockStubs.dataset.find.photonEnergyFilter,
+        message: "value and unit inside scientificMetadata"
+      },
+      {
+        args: mockStubs.dataset.find.photonEnergyFilter.map(
+          dataset => renameKeys(dataset)
+        ),
+        message: "v and u inside scientificMetadata"
+      }
+    ];
+    testsPhotonEnergy.forEach(({ args, message }) => {
+      context(
+        "where parameters has a photon energy in the range 880-990 eV",
+        () => {
+          it(`should return en array of datasets matching the parameter from ${message}`, (done) => {
+            sandbox
+              .stub(ScicatDatasetService.prototype, "find")
+              .resolves(args);
 
-          const filter = JSON.stringify({
-            include: [
-              {
-                relation: "parameters",
-                scope: {
-                  where: {
-                    and: [
-                      {
-                        name: "photon_energy",
-                      },
-                      {
-                        value: {
-                          between: [880, 990],
+            const filter = JSON.stringify({
+              include: [
+                {
+                  relation: "parameters",
+                  scope: {
+                    where: {
+                      and: [
+                        {
+                          name: "photon_energy",
                         },
-                      },
-                      {
-                        unit: "eV",
-                      },
-                    ],
+                        {
+                          value: {
+                            between: [880, 990],
+                          },
+                        },
+                        {
+                          unit: "eV",
+                        },
+                      ],
+                    },
                   },
                 },
-              },
-            ],
-          });
-          request(app)
-            .get(requestUrl + "?filter=" + filter)
-            .set("Accept", "application/json")
-            .expect(200)
-            .expect("Content-Type", /json/)
-            .end((err, res) => {
-              if (err) throw err;
+              ],
+            });
+            request(app)
+              .get(requestUrl + "?filter=" + filter)
+              .set("Accept", "application/json")
+              .expect(200)
+              .expect("Content-Type", /json/)
+              .end((err, res) => {
+                if (err) throw err;
 
-              expect(res.body).to.be.an("array");
-              res.body.forEach((dataset) => {
-                expect(dataset).to.have.property("pid");
-                expect(dataset).to.have.property("title");
-                expect(dataset).to.have.property("isPublic");
-                expect(dataset).to.have.property("creationDate");
-                expect(dataset).to.have.property("score");
-                expect(dataset).to.have.property("parameters");
-                expect(dataset.parameters).to.be.an("array").and.not.empty;
-                dataset.parameters.forEach((parameter) => {
-                  expect(parameter.name).to.equal("photon_energy");
-                  expect(parameter.value).to.be.within(880, 990);
-                  expect(parameter.unit).to.equal("eV");
+                expect(res.body).to.be.an("array");
+                res.body.forEach((dataset) => {
+                  expect(dataset).to.have.property("pid");
+                  expect(dataset).to.have.property("title");
+                  expect(dataset).to.have.property("isPublic");
+                  expect(dataset).to.have.property("creationDate");
+                  expect(dataset).to.have.property("score");
+                  expect(dataset).to.have.property("parameters");
+                  expect(dataset.parameters).to.be.an("array").and.not.empty;
+                  dataset.parameters.forEach((parameter) => {
+                    expect(parameter.name).to.equal("photon_energy");
+                    expect(parameter.value).to.be.within(880, 990);
+                    expect(parameter.unit).to.equal("eV");
+                  });
                 });
+                done();
               });
-              done();
-            });
-        });
+          });
+        },
+      );
+    });
+
+    const testsSolidCopper = [
+      {
+        args: mockStubs.dataset.find.solidCopperFilter,
+        message: "value and unit inside scientificMetadata"
       },
-    );
+      {
+        args: mockStubs.dataset.find.solidCopperFilter.map(
+          dataset => renameKeys(dataset)
+        ),
+        message: "v and u inside scientificMetadata"
+      }
+    ];
+    testsSolidCopper.forEach(({ args, message }) => {
+      context(
+        "where parameters includes a solid sample containing copper",
+        () => {
+          it(`should return an array of datasets matching the parameter from ${message}`, (done) => {
+            sandbox
+              .stub(ScicatDatasetService.prototype, "find")
+              .resolves(args);
 
-    context(
-      "where parameters includes a solid sample containing copper",
-      () => {
-        it("should return en array of datasets matching the parameter", (done) => {
-          sandbox
-            .stub(ScicatDatasetService.prototype, "find")
-            .resolves(mockStubs.dataset.find.solidCopperFilter);
-
-          const filter = JSON.stringify({
-            include: [
-              {
-                relation: "parameters",
-                scope: {
-                  where: {
-                    or: [
-                      {
-                        and: [
-                          {
-                            name: "sample_state",
-                          },
-                          {
-                            value: "solid",
-                          },
-                        ],
-                      },
-                      {
-                        and: [
-                          {
-                            name: "chemical_formula",
-                          },
-                          {
-                            value: "Cu",
-                          },
-                        ],
-                      },
-                    ],
+            const filter = JSON.stringify({
+              include: [
+                {
+                  relation: "parameters",
+                  scope: {
+                    where: {
+                      or: [
+                        {
+                          and: [
+                            {
+                              name: "sample_state",
+                            },
+                            {
+                              value: "solid",
+                            },
+                          ],
+                        },
+                        {
+                          and: [
+                            {
+                              name: "chemical_formula",
+                            },
+                            {
+                              value: "Cu",
+                            },
+                          ],
+                        },
+                      ],
+                    },
                   },
                 },
-              },
-            ],
-          });
-          request(app)
-            .get(requestUrl + "?filter=" + filter)
-            .set("Accept", "application/json")
-            .expect(200)
-            .expect("Content-Type", /json/)
-            .end((err, res) => {
-              if (err) throw err;
-
-              expect(res.body).to.be.an("array");
-              res.body.forEach((dataset) => {
-                expect(dataset).to.have.property("pid");
-                expect(dataset).to.have.property("title");
-                expect(dataset).to.have.property("isPublic");
-                expect(dataset).to.have.property("creationDate");
-                expect(dataset).to.have.property("score");
-                expect(dataset).to.have.property("parameters");
-                expect(dataset.parameters).to.be.an("array").and.not.empty;
-                expect(dataset.parameters[0].name).to.equal("chemical_formula");
-                expect(dataset.parameters[0].value).to.equal("Cu");
-                expect(dataset.parameters[1].name).to.equal("sample_state");
-                expect(dataset.parameters[1].value).to.equal("solid");
-              });
-              done();
+              ],
             });
-        });
-      },
-    );
+            request(app)
+              .get(requestUrl + "?filter=" + filter)
+              .set("Accept", "application/json")
+              .expect(200)
+              .expect("Content-Type", /json/)
+              .end((err, res) => {
+                if (err) throw err;
+
+                expect(res.body).to.be.an("array");
+                res.body.forEach((dataset) => {
+                  expect(dataset).to.have.property("pid");
+                  expect(dataset).to.have.property("title");
+                  expect(dataset).to.have.property("isPublic");
+                  expect(dataset).to.have.property("creationDate");
+                  expect(dataset).to.have.property("score");
+                  expect(dataset).to.have.property("parameters");
+                  expect(dataset.parameters).to.be.an("array").and.not.empty;
+                  expect(dataset.parameters[0].name).to.equal("chemical_formula");
+                  expect(dataset.parameters[0].value).to.equal("Cu");
+                  expect(dataset.parameters[1].name).to.equal("sample_state");
+                  expect(dataset.parameters[1].value).to.equal("solid");
+                });
+                done();
+              });
+          });
+        },
+      );
+    });
 
     context("where parameters has a temperature below 80 °C", () => {
       it("should return en array of datasets matching the parameter", (done) => {


### PR DESCRIPTION
## Description

As catamel converts to SI the scientificMetadata with value and unit or v and u, this PR updates the search-api in order to work with v and u, by doing the mapping from the user query to either v and u or value and unit
## Motivation
As catamel converts to SI the scientificMetadata with value and unit or v and u, the search-api needs to do the same
## Background on use case, changes needed
User inputs query {"name":"Name","value":"Value","unit":"Unit"} and search-api will return datasets with value and unit or v and u matching the query 
## Fixes:

* test case was relying on the wrong input

## Changes:

* filter with both v and u or value and unit
* map response with v and u or value and unit

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
