### PR TITLE
Fix parameters

### DIFF
--- a/common/response-mapper.js
+++ b/common/response-mapper.js
@@ -236,13 +236,19 @@ exports.members = (scicatPublishedData, filter) => {
  */
 
 exports.parameters = (scientificMetadata, filter) => {
-  const parameter = utils.extractParamaterFilter(filter.where);
+  const parameters = (
+    filter.where.or ? filter.where.or : [filter.where]
+  ).reduce((o, c) => {
+    const parameter = utils.extractParamaterFilter(c);
+    o[parameter.name] = parameter;
+    return o;
+  }, {});
   return Object.keys(scientificMetadata).map((key) => {
-    if (key === parameter.name) {
+    if (parameters[key] && parameters[key].unit) {
       const { value, unit } = utils.convertToUnit(
         scientificMetadata[key].valueSI,
         scientificMetadata[key].unitSI,
-        parameter.unit
+        parameters[key].unit
       );
       return {
         name: key,

--- a/common/response-mapper.js
+++ b/common/response-mapper.js
@@ -236,13 +236,9 @@ exports.members = (scicatPublishedData, filter) => {
  */
 
 exports.parameters = (scientificMetadata, filter) => {
-  const parameters = (
+  const parameters = utils.extractParamaterFilterMapping(
     filter.where.or ? filter.where.or : [filter.where]
-  ).reduce((o, c) => {
-    const parameter = utils.extractParamaterFilter(c);
-    o[parameter.name] = parameter;
-    return o;
-  }, {});
+  );
   return Object.keys(scientificMetadata).map((key) => {
     if (parameters[key] && parameters[key].unit) {
       const { value, unit } = utils.convertToUnit(

--- a/common/utils.js
+++ b/common/utils.js
@@ -173,3 +173,19 @@ exports.extractParamaterFilter = (where) => {
     return { name: null, value: null, unit: null };
   }
 };
+
+
+/**
+ * Creates an object with the name of the parameter as key and values from extractParamaterFilter
+ * @param {object} where PaNOSC parameter where filter object
+ * @returns {object} Object with the name of the parameter as key and values from extractParamaterFilter
+ */
+exports.extractParamaterFilterMapping = (filter) => (
+  filter.reduce(
+    (o, c) => {
+      const parameter = this.extractParamaterFilter(c);
+      o[parameter.name] = parameter;
+      return o;
+    },
+    {})
+);

--- a/test/response-mapper.test.js
+++ b/test/response-mapper.test.js
@@ -1,0 +1,118 @@
+"use strict";
+
+const expect = require("chai").expect;
+const responseMapper = require("../common/response-mapper");
+
+describe("response-mapper", () => {
+  describe("parameters", () => {
+
+    const tests = [
+      {
+        args: {
+          data: {
+            name1: { valueSI: 1, unitSI: "m" },
+            name2: { value: 5000, unit: "g" },
+          },
+          filter: {
+            and: [
+              { name: "name1" },
+              { value: 1000 },
+              { unit: "mm" }
+            ]
+          }
+        },
+        expected: [
+          { name: "name1", value: 1000, unit: "mm" },
+          { name: "name2", value: 5000, unit: "g" }
+        ],
+        message: "list with parameters converted to units in the filter"
+      },
+      {
+        args: {
+          data: {
+            name1: { value: "Cu", unit: "" }
+          },
+          filter: {
+            and: [
+              { name: "name1" },
+              { value: "Cu" }
+            ]
+          }
+        },
+        expected: [
+          { name: "name1", value: "Cu", unit: undefined }
+        ],
+        message: "list with a parameter without running unit conversion"
+      },
+      {
+        args: {
+          data: {
+            name1: { valueSI: 1, unitSI: "m" },
+            name2: { valueSI: 5, unitSI: "kg" },
+          },
+          filter: {
+            or: [
+              {
+                and: [
+                  { name: "name1" },
+                  { value: 1000 },
+                  { unit: "mm" }]
+              },
+              {
+                and: [
+                  { name: "name2" },
+                  { value: 5000 },
+                  { unit: "g" }
+                ]
+              }
+            ]
+          }
+        },
+        expected: [
+          { name: "name1", value: 1000, unit: "mm" },
+          { name: "name2", value: 5000, unit: "g" }
+        ],
+        message: "list with both values converted to filter units, from the or condition"
+      },
+      {
+        args: {
+          data: {
+            name1: { valueSI: 1, unitSI: "m" },
+          },
+          filter: {
+            or: [
+              {
+                and: [
+                  { name: "name1" },
+                  { value: 1000 },
+                  { unit: "mm" }
+                ]
+              },
+              {
+                and: [
+                  { name: "name2" },
+                  { value: 5000 },
+                  { unit: "g" }
+                ]
+              }
+            ]
+          }
+        },
+        expected: [
+          { name: "name1", value: 1000, unit: "mm" }
+        ],
+        message: "list disregarding one of the two conversions from the filter"
+      },
+    ];
+    tests.forEach(({ args, expected, message }) => {
+      context(`${message}`, () => {
+        it(`should return a ${message}`, (done) => {
+          const inclusions = responseMapper.parameters(args.data, { where: args.filter });
+          expect(inclusions).to.eql(expected);
+          done();
+        });
+      });
+    });
+  });
+
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -253,10 +253,8 @@ describe("utils", () => {
       }
     );
   });
-});
 
-describe("extractParamaterFilterMapping", () => {
-  describe("extractParamaterFilter", () => {
+  describe("extractParamaterFilterMapping", () => {
     context(
       "Creates an object with the name of the parameter as key and values from extractParamaterFilter",
       () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -244,10 +244,32 @@ describe("utils", () => {
       () => {
         it("Object with the extracted name, value and unit", (done) => {
           const input = {
-            and: [{ name: "aName", value: "aValue", unit: "aUnit" }],
+            and: [{ name: "aName" }, { value: "aValue" }, { unit: "aUnit" }],
           };
           const expected = { name: "aName", value: "aValue", unit: "aUnit" };
           expect(utils.extractParamaterFilter(input)).to.eql(expected);
+          done();
+        });
+      }
+    );
+  });
+});
+
+describe("extractParamaterFilterMapping", () => {
+  describe("extractParamaterFilter", () => {
+    context(
+      "Creates an object with the name of the parameter as key and values from extractParamaterFilter",
+      () => {
+        it("Object with name as key and values from extractParamaterFilter", (done) => {
+          const input = [
+            { and: [{ name: "aName" }, { value: "aValue" }, { unit: "aUnit" }] },
+            { and: [{ name: "aName1" }, { value: "aValue1" }, { unit: "aUnit1" }] }
+          ];
+          const expected = {
+            aName: { name: "aName", value: "aValue", unit: "aUnit" },
+            aName1: { name: "aName1", value: "aValue1", unit: "aUnit1" }
+          };
+          expect(utils.extractParamaterFilterMapping(input)).to.eql(expected);
           done();
         });
       }


### PR DESCRIPTION
## Description

Add conversion to units also when filtering with or conditions on parameters. To do this, there is a loop over the conditions in the or in the parameters function of `response-mapper.js`
## Motivation
A user could look for datasets satisfying one of the two clauses in the or condition in the filter. All the scientificMetadata of results need to be converted to the correct unit. This PR is fixing this.
## Fixes:

* fix one test
* check if filter has unit, otherwise skip the conversion

## Changes:

* function added to create an object from the filter
* convert on all filters in or clause

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
