### PR TITLE
Tech

### DIFF
--- a/common/cache.js
+++ b/common/cache.js
@@ -1,0 +1,63 @@
+"use strict";
+
+exports.LoopbackCache = class {
+
+  /**
+   * Sets the internal default timeout and collection to use to store the cache
+   * in the loopback datasource
+   * @param {object} config Object which might contain the collection to use to
+   * store the cache and the default cache timeout
+   */
+
+  constructor(config) {
+
+    this.sttl = config.sttl;
+    this.collection = config.collection;
+  }
+
+  /**
+   * Stores the value list or object in the loopback datasource
+   * @param {string|number} key Id to use to refernce the cached element. Not
+   * used, added to maintain node-cache signature
+   * @param {object|object[]} value List of objects or single object to store in
+   *  the loopback datasource
+   * @param {number} [ttl] Cache timeout to set on the value being cached
+   */
+
+  // eslint-disable-next-line no-unused-vars
+  async set(key, value, ttl) {
+    var app = require("../server/server");
+    const valueArray = Array.isArray(value) || value.next ?
+      value : [value];
+    const promises = [];
+    for (let v of valueArray) {
+      promises.push(app.models[this.collection].upsert(
+        ttl != null ? { ...v, ttl: ttl } : v));
+    }
+    await Promise.all(promises);
+  }
+
+  /**
+   * Gets the cache from the loopback datasource using the provided filter. If
+   * the cache has expaired it clears the item
+   * @param {object} filter Object containing the loopback filter to use to
+   * retrieve the cache
+   * @returns {object[]|null|Array} When the cache is cleared or empty, it
+   * returns null, otherwise the items after having applied the filter
+   */
+
+  async get(filter) {
+    var app = require("../server/server");
+    const collection = app.models[this.collection];
+    const data = await collection.find(filter);
+    if (data[0]
+      && data[0].createdAt + (
+        data[0].ttl != undefined ? data[0].ttl : this.sttl) * 1000 < Date.now()
+    ) {
+      await collection.destroyAll(filter.where);
+      return [];
+    } else {
+      return data;
+    }
+  }
+};

--- a/common/filter-mapper.js
+++ b/common/filter-mapper.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const mappings = require("./mappings");
+const { technique } = require("./technique-filter-builder");
 const utils = require("./utils");
 
 /**
@@ -9,7 +10,7 @@ const utils = require("./utils");
  * @returns {object} SciCat loopback filter object
  */
 
-exports.dataset = (filter) => {
+exports.dataset = async (filter) => {
   if (!filter) {
     return null;
   } else {
@@ -31,6 +32,7 @@ exports.dataset = (filter) => {
         (inclusion) => inclusion.relation === "techniques"
       );
       if (techniques && techniques.scope && techniques.scope.where) {
+        techniques.scope.where = await technique.buildFilter(techniques.scope.where);
         scicatFilter = mapField(techniques, scicatFilter);
       }
       const include = filter.include

--- a/common/models/dataset.js
+++ b/common/models/dataset.js
@@ -34,7 +34,7 @@ module.exports = function (Dataset) {
       }
     }
 
-    const scicatFilter = filterMapper.dataset(filter);
+    const scicatFilter = await filterMapper.dataset(filter);
     const datasets = await scicatDatasetService.find(scicatFilter);
     // perform scoring only if it is enabled
     if (pssScoreEnabled) {
@@ -70,7 +70,7 @@ module.exports = function (Dataset) {
    */
 
   Dataset.findById = async function (id, filter) {
-    const scicatFilter = filterMapper.dataset(filter);
+    const scicatFilter = await filterMapper.dataset(filter);
     const dataset = await scicatDatasetService.findById(id, scicatFilter);
     return await responseMapper.dataset(dataset, filter);
   };
@@ -81,7 +81,7 @@ module.exports = function (Dataset) {
    */
 
   Dataset.count = async function (where) {
-    const scicatFilter = filterMapper.dataset({ where });
+    const scicatFilter = await filterMapper.dataset({ where });
     return await scicatDatasetService.count(scicatFilter);
   };
 

--- a/common/models/technique.json
+++ b/common/models/technique.json
@@ -8,7 +8,8 @@
   "properties": {
     "pid": {
       "type": "string",
-      "required": true
+      "required": true,
+      "id": true
     },
     "name": {
       "type": "string",

--- a/common/response-mapper.js
+++ b/common/response-mapper.js
@@ -114,7 +114,7 @@ exports.document = async (scicatPublishedData, filter, scores = {}) => {
   const inclusions = utils.getInclusions(filter);
 
   if (Object.keys(inclusions).includes("datasets")) {
-    const scicatFilter = filterMapper.dataset(inclusions.datasets);
+    const scicatFilter = await filterMapper.dataset(inclusions.datasets);
     const pidArray = scicatPublishedData.pidArray.map((pid) =>
       pid.split("/")[0] === pid.split("/")[1]
         ? pid.split("/").slice(1).join("/")

--- a/common/technique-filter-builder.js
+++ b/common/technique-filter-builder.js
@@ -1,0 +1,199 @@
+"use strict";
+
+var config = {};
+try {
+  config = require("../config.json");
+} catch (error) {
+  console.log("missing config file, applying defaults");
+}
+const cache = require("./cache");
+const techniqueGetter = require("./technique-getter");
+const utils = require("./utils");
+
+
+exports.FreeFormTechniques = class {
+
+  /**
+   * Returns the untouched input
+   * @param {object} filter PaNOSC loopback filter object
+   * @returns {object} Object equal to filter
+   */
+
+  buildFilter(filter) {
+    return filter;
+  }
+
+};
+
+exports.BioPortalLoopbackCacheBuilder = class {
+
+  /**
+   * Creates an instance of BioPortalTechniques and LoopbackCache with the
+   * provided config
+   * @param {object} config Object containing the config values for cache and
+   * TechniqueGetter
+   */
+
+  constructor(config) {
+    this.techniqueGetter = new techniqueGetter.BioPortalTechniques(config);
+    this.cache = new cache.LoopbackCache(config.cache);
+  }
+
+  /**
+   * Starting from loopback AND filter it adds synonym to it and returns the
+   * intersection of relatives
+   * @param {object} filter PaNOSC loopback filter object
+   * @returns {object} Object the filter + synonym, joined by an OR condition,
+   * and returns the intersection of relatives
+   */
+
+  async and(filter) {
+    var techniques;
+    for (let f of filter) {
+      let synonym = this.constructor.createSynonym(f);
+      if (synonym) {
+        synonym = { or: [f, synonym] };
+      }
+      if (techniques) {
+        const technique = await this.buildTechniques(synonym || f);
+        const union = utils.unionArraysOfObjects(technique, "relatives");
+        techniques = utils.intersectArraysOfObjects(
+          [union, techniques], "relatives");
+      } else {
+        techniques = await this.buildTechniques(synonym || f);
+        techniques = utils.unionArraysOfObjects(techniques, "relatives");
+      }
+      if (techniques.relatives.length === 0) break;
+    }
+    return techniques.relatives;
+  }
+
+  /**
+   * Starting from loopback filter it adds synonym to it and returns the
+   * relatives
+   * @param {object} filter PaNOSC loopback filter object
+   * @returns {object} Object the filter + synonym, joined by an OR condition,
+   * and returns the relatives
+   */
+
+  async flat(filter) {
+    const synonymFilter = this.constructor.createSynonym(filter);
+    const techniques = await this.buildTechniques(
+      synonymFilter ? { or: [filter, synonymFilter] } : filter);
+    return utils.unionArraysOfObjects(techniques, "relatives").relatives;
+  }
+
+  /**
+   * Starting from loopback OR filter it adds synonym to it and returns the
+   * union of relatives
+   * @param {object} filter PaNOSC loopback filter object
+   * @returns {object} Object the filter + synonym, joined by an OR condition,
+   * and returns the union of relatives
+   */
+
+  async or(filter) {
+    const fullFilter = filter.reduce((start, f) => {
+      const synonym = this.constructor.createSynonym(f);
+      if (synonym) {
+        return start.concat([f, synonym]);
+      }
+      return start.concat(f);
+    }, []);
+    const techniques = await this.buildTechniques({ or: fullFilter });
+    return utils.unionArraysOfObjects(techniques, "relatives").relatives;
+  }
+
+  /**
+   * Returns the same filter structure used by the NAME field, replacing the
+   * NAME key with SYNONYM
+   * @param {object} item PaNOSC loopback filter object
+   * @returns {object} filter where the NAME key is replaced by SYNONYM
+   */
+
+  static createSynonym(item) {
+    const synonym = Object.keys(item).reduce((o, key) => (
+      key === "name" ? o["synonym"] = item[key] : o[key] = item[key], o),
+    {});
+    return synonym.synonym ? synonym : null;
+  }
+
+  /**
+   * Tranforms an object with the structure of BioPortalTechniques to a format
+   * that can be used by LoopbackCache
+   * @param {object} obj BioPortal nodes attribute
+   * @param {object} [keyMap] Keymap to map BioPortal.nodes to list of object
+   * for LoopbackCache
+   * @returns {object[]} List of objects that can be saved using LoopbackCache
+   */
+
+  static * prepareForCache(tech, keyMap = {
+    name: "prefLabel", synonym: "synonym",
+    pid: "@id"
+  }) {
+    var index = 0;
+    while (index < tech.collection.length) {
+      const out = Object.keys(keyMap).reduce((o, km) => (
+        o[km] = tech.collection[index][keyMap[km]], o), {});
+      out.relatives = [...tech.nodes.relatives[out.pid]];
+      out.createdAt = Date.now();
+      yield out;
+      index++;
+    }
+  }
+
+  /**
+   * Returns Loopback filter with relatives from filtered LoopbacCache or
+   * BioPortal in INQ clause
+   * @param {object} filter PaNOSC loopback filter object
+   * @returns {object} Loopback filter with relatives from filtered LoopbacCache
+   * or BioPortal in INQ clause
+   */
+
+  async buildFilter(filter) {
+    var techniques;
+    if (filter.and) {
+      techniques = await this.and(filter.and);
+    } else if (filter.or) {
+      techniques = await this.or(filter.or);
+    } else {
+      techniques = await this.flat(filter);
+    }
+    return { pid: { inq: techniques } };
+  }
+
+  /**
+   * Builds the items from filtered LoopbacCache or BioPortal
+   * @param {object} filter PaNOSC loopback filter object including synonyms
+   * @returns {object[]} Array of objects from filtered LoopbacCache or
+   * BioPortal
+   */
+
+  async buildTechniques(filter) {
+    const first = await this.cache.get({ limit: 1 });
+    if (first.length > 0) {
+      const ttl = this.cache.sttl;
+      var outdated = await this.cache.get({
+        where: {
+          createdAt:
+            { lt: Date.now() - ttl * 1000 }
+        }
+      });
+    }
+    if ((outdated && outdated.length > 0) || first.length === 0) {
+      await this.techniqueGetter.build();
+      const items = this.constructor.prepareForCache(this.techniqueGetter);
+      await this.cache.set(null, items);
+    }
+    return await this.cache.get({ where: filter });
+  }
+
+};
+
+exports.BioPortalTechniques = {
+  LoopbackCache: this.BioPortalLoopbackCacheBuilder
+};
+
+exports.technique = new (config.technique ?
+  this[config.technique.class][config.technique.cache.class]:
+  this["FreeFormTechniques"]
+)(config.technique);

--- a/common/technique-getter.js
+++ b/common/technique-getter.js
@@ -1,0 +1,178 @@
+"use strict";
+
+const superagent = require("superagent");
+const utils = require("./utils");
+
+exports.BioPortalTechniques = class {
+
+  /**
+   * Sets url and apikey to use to get data from BioPortal
+   * @param {object} config Object with the url and the apiKey to use to
+   * access BioPortal
+   */
+
+  constructor(config) {
+    this.url = config.url;
+    this.apiKey = config.apiKey;
+  }
+
+  /**
+   * Sets the url, the queryParams and the headers to use
+   */
+
+  composeURL() {
+    this.headers = {
+      "Content-Type": "application/json",
+      "Accept": "application/json",
+      "Authorization": `apikey token=${this.apiKey}`,
+    };
+    this.queryParams = { "include": "children,prefLabel,synonym,parents" };
+    this.url = new URL(this.url);
+  }
+
+  /**
+   * Concats together the responses of BioPortal from different pages
+   * @returns {Array} List of responses from BioPortal
+   */
+
+  async getCollection() {
+    const [url, headers, queryParams] = [
+      this.url, this.headers, this.queryParams];
+    const page = queryParams.page || 1;
+    const res = await superagent.get(url).query(
+      Object.assign(queryParams, { page: page })).set(headers);
+    const body = JSON.parse(res.text);
+    var collection = body.collection;
+    const promises = utils.range(page + 1, body.pageCount).map(
+      p =>
+        superagent.get(url).query(
+          Object.assign(queryParams, { page: p })
+        ).set(headers).then(
+          res => JSON.parse(res.text).collection
+        )
+    );
+    return collection.concat(...await Promise.all(promises));
+  }
+
+  /**
+   * From the list of responses from BioPortal,
+   * it creates an object where firstKey is the type of object
+   * and as value a second object with an id and where the value is BioPortal
+   * response.firstKey
+   * @param {object[]} collection List of objects each being an item from the
+   * response from BioPortal
+   * @returns {Object} Object where firstKey is the type of object
+   * and as value a second object with an id and where the value is BioPortal
+   * response.firstKey
+   */
+
+  static buildNodes(collection) {
+    const o = {
+      "names": {}, "@id": {}, "children": {}, "synonym": {},
+      "synonymT": {}, "leaves": [], "parents": {}, "roots": []
+    };
+    for (var node of collection) {
+      const _id = node["@id"];
+      o["names"][_id] = node["prefLabel"];
+      o["@id"][node["prefLabel"]] = _id;
+      o["children"][_id] = node["children"];
+      o["synonym"][_id] = node["synonym"];
+      if (node["synonym"]) node["synonym"].map(
+        synonym => o["synonymT"][synonym] = _id);
+      if (node["children"].length == 0) o["leaves"].push(_id);
+      o["parents"][_id] = node["parents"];
+      if (o["parents"][_id].length == 0) o["roots"].push(_id);
+    }
+    return o;
+  }
+
+  /**
+   * Removes the extra white spaces from the input item
+   * @param {string} item String potentially with extra white spaces
+   * @returns {string} String with extra white spaces removed
+   */
+
+  static prefLabel(item) {
+    return item.replace(/\s+/g, " ").trim();
+  }
+
+  /**
+   * Removes the extra white spaces from each string in the array
+   * @param {string[]} item Array of strings potentially with extra white spaces
+   * @returns {string[]} Array of strings with extra white spaces removed
+   */
+
+  static synonym(item) {
+    return item.map(this.prefLabel);
+  }
+
+  /**
+   * Takes the element '@id' from each object in the item array
+   * @param {object[]} item Array of objects each with '@id' key
+   * @returns {string[]} Array of strings being the value of '@id' in each
+   * object in the input array
+   */
+
+  static children(item) {
+    return item.map(child => child["@id"]);
+  }
+
+  /**
+   * Takes the element '@id' from each object in the item array unless all
+   * objects in the array have prefLabel null, thus return []
+   * @param {object[]} item Array of objects each with '@id' and prefLabel keys
+   * @returns {string[]} Array of strings being the value of '@id' in each
+   * object in the input array or []
+   */
+
+  static parents(item) {
+    if (item.filter(e => e["prefLabel"]).length == 0) {
+      return [];
+    }
+    else {
+      return item.map(parent => parent["@id"]);
+    }
+  }
+
+  /**
+   * From the list of responses from BioPortal it applies a first processing,
+   * applying the methods defined in the class which have the name of the keys.
+   * @param {object[]} collection List of objects each being an item from the
+   * response from BioPortal
+   * @returns {Generator} Generator having applied the methods defined in the
+   * class which have the name of the keys
+   */
+
+  * processCollection(collection) {
+    this.collection = [];
+    let index = 0;
+    while (index < collection.length) {
+      const col = collection[index];
+      const processed = Object.keys(col).reduce((obj, key) => {
+        obj[key] = this.constructor[key] ?
+          this.constructor[key](col[key]) : col[key];
+        return obj;
+      }, {});
+      yield processed;
+      this.collection.push(processed);
+      index++;
+    }
+  }
+
+  /**
+   * Builds and sets a graph with key the id of the BioPortal item and value
+   * the relatives (ancestor or descendants)
+   * @returns {BioPortalTechniques} Returns the instance with the attributes set
+   */
+
+  async build() {
+    this.composeURL();
+    const collection = this.processCollection(
+      await this.getCollection());
+    const nodes = this.constructor.buildNodes(collection);
+    nodes.relatives = utils.buildForest(nodes.leaves, nodes.parents);
+    this.nodes = nodes;
+    return this;
+  }
+
+};

--- a/common/utils.js
+++ b/common/utils.js
@@ -326,23 +326,3 @@ exports.unionArraysOfObjects = (listOfObjects, keyOfObject) => (
     )]
   }
 );
-
-/**
- * Intersects each array belonging to the same key of each object
- * @param {object} listOfObjects List of objects having a list as value of
- * keyOfObject
- * @param {object} keyOfObject Key to use to get the list from each object
- * @returns {object} Object with key keyOfObject and value of arrays containing
- * the intersection of the object keyOfObject property
- */
-
-exports.intersectArraysOfObjects = (listOfObjects, keyOfObject) => (
-  {
-    [keyOfObject]: listOfObjects.reduce((start, obj) =>
-      start ?
-        [...new Set(start.filter(i => obj[keyOfObject].includes(i)))] :
-        obj[keyOfObject],
-    null
-    )
-  }
-);

--- a/common/utils.js
+++ b/common/utils.js
@@ -177,9 +177,10 @@ exports.extractParamaterFilter = (where) => {
 
 /**
  * Creates an object with the name of the parameter as key and values from extractParamaterFilter
- * @param {object} where PaNOSC parameter where filter object
+ * @param {object} filter PaNOSC parameter where filter object
  * @returns {object} Object with the name of the parameter as key and values from extractParamaterFilter
  */
+
 exports.extractParamaterFilterMapping = (filter) => (
   filter.reduce(
     (o, c) => {
@@ -248,3 +249,100 @@ exports.compareDocuments = (a, b) => {
   }
   return 0;
 };
+/**
+ * From a single rooted graph it builds an object with the node as a key and the
+ *  list relatives (ancestors or descendants) as value
+ * @param {string} node Name or id of the node where to start
+ * @param {object} relatives Object with key the node and list of nearest
+ * relatives (parents or children) as value
+ * @param {object} [ids] Object with a map relatives list to ids
+ * @param {object} [tree] Object used to store the output
+ * @returns {object} Object with the node as a key and the list relatives
+ * (ancestors or descendants) as value
+ */
+
+exports.buildTree = (node, relatives, ids = {}, tree = {}) => {
+  tree[node] = tree[node] || new Set([ids[node] || node]);
+  if (!relatives[node]) return tree;
+  relatives[node].map(
+    relative => (
+      tree[relative] = tree[relative] || new Set([ids[relative] || relative]),
+      tree[node].forEach(i => tree[relative].add(i)),
+      this.buildTree(relative, relatives, ids, tree)
+
+    )
+  );
+  return tree;
+};
+
+/**
+ * It combines many single rooted graphs togheter to create a composition of
+ * graphs
+ * @param {string[]} startList List of names of starting nodes of single rooted
+ * graphs
+ * @param {Array} relatives Object with key the node and list of nearest
+ * relatives (parents or children) as value
+ * @param {object} [ids] Object with a map relatives list to ids
+ * @returns {object} Object with the node as a key and the list relatives
+ * (ancestors or descendants) as value
+ */
+
+exports.buildForest = (startList, relatives, ids) => (
+  startList.reduce((o, start) => (
+    this.buildTree(start, relatives, ids, o),
+    o
+  ),
+  {}
+  )
+);
+
+/**
+ * Returns a list of integers included in [start, end]
+ * @param {number} start Integer where to start the range from. Its value is
+ * included in the returned list
+ * @param {number} end Integer where to end the range. Its value is included in
+ * the returned list
+ * @returns {Array} List of integers
+ */
+
+exports.range = (start, end) => (
+  Array.from({ length: end - start + 1 }, (_, i) => start + i)
+);
+
+/**
+ * Unions each array belonging to the same key of each object
+ * @param {object} listOfObjects List of objects having a list as value of
+ * keyOfObject
+ * @param {object} keyOfObject Key to use to get the list from each object
+ * @returns {object} Object with key keyOfObject and value of arrays containing
+ * the union of the object keyOfObject property
+ */
+
+exports.unionArraysOfObjects = (listOfObjects, keyOfObject) => (
+  {
+    [keyOfObject]: [...new Set(listOfObjects.reduce((start, array) => (
+      start.push(...array[keyOfObject]), start),
+    [])
+    )]
+  }
+);
+
+/**
+ * Intersects each array belonging to the same key of each object
+ * @param {object} listOfObjects List of objects having a list as value of
+ * keyOfObject
+ * @param {object} keyOfObject Key to use to get the list from each object
+ * @returns {object} Object with key keyOfObject and value of arrays containing
+ * the intersection of the object keyOfObject property
+ */
+
+exports.intersectArraysOfObjects = (listOfObjects, keyOfObject) => (
+  {
+    [keyOfObject]: listOfObjects.reduce((start, obj) =>
+      start ?
+        [...new Set(start.filter(i => obj[keyOfObject].includes(i)))] :
+        obj[keyOfObject],
+    null
+    )
+  }
+);

--- a/docs/techniques-queries-examples.md
+++ b/docs/techniques-queries-examples.md
@@ -1,0 +1,2059 @@
+# Techniques Queries Examples
+
+This document illustrate how the techniques in the PaNOSC datasets are queried with real example.
+To run this examples, you need to run a SciCatLive version on your machie, which includes the PaNOSC Search Api.
+The results are the ones that you would get when running SciCatLive as is with its example datasets.
+
+## Datasets	
+
+In order to provide meaningful examples, we need to define few datasets and the related set of techniques which are tagged with.  
+The datasets are defined in the test dataset provided with the vanilla installation of SciCatLive, and are listed below for coneniency. Each dataset is listed with the technique that is tagged with and the relativer technique pid.
+
+
+| Dataset id                   | Technique Name                                                               | Technique PID  |
+| ---------------------------- | ---------------------------------------------------------------------------- | -------------- |
+| PID.SAMPLE.PREFIX/desy_ds1   | resonant inelastic x-ray scattering                                          | http://purl.org/pan-science/PaNET/PaNET01183 |
+| PID.SAMPLE.PREFIX/desy_ds2   | resonant inelastic x-ray scattering	                                        | http://purl.org/pan-science/PaNET/PaNET01183 |
+| PID.SAMPLE.PREFIX/desy_ds3   | resonant inelastic x-ray scattering	                                        | http://purl.org/pan-science/PaNET/PaNET01183 |
+| PID.SAMPLE.PREFIX/dls_ds1    | anomalous solution x-ray scattering	                                        | http://purl.org/pan-science/PaNET/PaNET01275 |
+| PID.SAMPLE.PREFIX/dls_ds2    | grazing incidence small angle x-ray scattering	                              | http://purl.org/pan-science/PaNET/PaNET01162 |
+| PID.SAMPLE.PREFIX/hzdr_ds1   | inelastic x-ray small angle scattering	                                      | http://purl.org/pan-science/PaNET/PaNET01281 |
+| PID.SAMPLE.PREFIX/maxiv_ds1  | resonant inelastic x-ray scattering	                                        | http://purl.org/pan-science/PaNET/PaNET01183 |
+| PID.SAMPLE.PREFIX/maxiv_ds2  | soft x-ray small angle scattering	                                          | http://purl.org/pan-science/PaNET/PaNET01282 |
+| PID.SAMPLE.PREFIX/psi_ds1    | magnetic x-ray tomography	                                                  | http://purl.org/pan-science/PaNET/PaNET01313 |
+| PID.SAMPLE.PREFIX/psi_ds2    | magnetic x-ray tomography                                                    | http://purl.org/pan-science/PaNET/PaNET01313 |
+| PID.SAMPLE.PREFIX/psi_ds3    | magnetic x-ray tomography                                                    | http://purl.org/pan-science/PaNET/PaNET01313 |
+| PID.SAMPLE.PREFIX/soleil_ds1 | x-ray emission spectroscopy                                                  | http://purl.org/pan-science/PaNET/PaNET01200 |
+| PID.SAMPLE.PREFIX/soleil_ds2 | x-ray emission spectroscopy                                                  | http://purl.org/pan-science/PaNET/PaNET01200 |
+| PID.SAMPLE.PREFIX/ukri_ds1   | x-ray emission spectroscopy ,<br /> magnetic x-ray tomography                | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+| PID.SAMPLE.PREFIX/ukri_ds2   | x-ray emission spectroscopy ,<br /> magnetic x-ray tomography                | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+| PID.SAMPLE.PREFIX/ukri_ds3   | x-ray emission spectroscopy ,<br /> magnetic x-ray tomography                | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+| PID.SAMPLE.PREFIX/ukri_ds4   | x-ray emission spectroscopy ,<br /> magnetic x-ray tomography                | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+| PID.SAMPLE.PREFIX/ukri_ds5   | x-ray emission spectroscopy ,<br /> grazing incidence small angle scattering | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> http://purl.org/pan-science/PaNET/PaNET01162 |
+| PID.SAMPLE.PREFIX/ukri_ds6   | x-ray emission spectroscopy ,<br /> anomalous solution x-ray scattering      | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> http://purl.org/pan-science/PaNET/PaNET01275 |
+
+Here is the information about the techniques and their pid/URL
+
+| Technique name                                  | Technique pid / URL                          |
+| ----------------------------------------------- | -------------------------------------------- |
+| resonant inelastic x-ray scattering             | http://purl.org/pan-science/PaNET/PaNET01183 |
+| anomalous solution x-ray scattering	            | http://purl.org/pan-science/PaNET/PaNET01275 |
+| grazing incidence small angle x-ray scattering  | http://purl.org/pan-science/PaNET/PaNET01162 |
+| inelastic x-ray small angle scattering	        | http://purl.org/pan-science/PaNET/PaNET01281 |
+| soft x-ray small angle scattering	              | http://purl.org/pan-science/PaNET/PaNET01282 |
+| magnetic x-ray tomography	                      | http://purl.org/pan-science/PaNET/PaNET01313 |
+| x-ray emission spectroscopy                     | http://purl.org/pan-science/PaNET/PaNET01200 |
+
+
+## Notes
+
+ - In the example section below, only the relevant portion of the query is presented
+ - Techniques are referenced by name, but it is preferred to execute the query using their pids
+
+## Examples
+
+### Query 1
+
+#### Use case:
+A user is looking for datasets which are tagged with the term *x-ray emission spectroscopy* or any of its descendants
+
+#### User query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "name": "x-ray emission spectroscopy"
+        }
+      }
+    }
+  ]
+}
+```
+
+Compact format:  
+```json
+{"include":[{"relation":"techniques","scope":{"where":{"name":"x-ray emission spectroscopy"}}}]}
+```
+Request URL:  
+`http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22name%22%3A%22x-ray%20emission%20spectroscopy%22%7D%7D%7D%5D%7D`
+
+Curl commnad
+```bash
+curl -X GET --header 'Accept: application/json' 'http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22name%22%3A%22x-ray%20emission%20spectroscopy%22%7D%7D%7D%5D%7D'
+```
+
+Equivalent user query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "name" : {"eq" : "x-ray emission spectroscopy"}
+        }
+      }
+    }
+  ]
+}
+
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "pid" : {"eq" : "http://purl.org/pan-science/PaNET/PaNET01200"}
+        }
+      }
+    }
+  ]
+}
+```
+
+Interpreted query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "pid": { "inq" : [
+            "http://purl.org/pan-science/PaNET/PaNET01200"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Dataset returned
+*PID.SAMPLE.PREFIX/soleil_ds1 , PID.SAMPLE.PREFIX/soleil_ds2 , PID.SAMPLE.PREFIX/ukri_ds1 , PID.SAMPLE.PREFIX/ukri_ds2 , PID.SAMPLE.PREFIX/ukri_ds3 , PID.SAMPLE.PREFIX/ukri_ds4 , PID.SAMPLE.PREFIX/ukri_ds5 , PID.SAMPLE.PREFIX/ukri_ds6*
+
+\
+Query details: 
+- techniques highlighted in **bold** are the techniques that match the query submitted
+ 
+ | Selected | Dataset id | Technique Name | Technique PID |
+ | :-: | - | - | - |
+ |   | PID.SAMPLE.PREFIX/desy_ds1 | resonant inelastic x-ray scattering | http://purl.org/pan-science/PaNET/PaNET01183 | 
+ |   | PID.SAMPLE.PREFIX/desy_ds2 | resonant inelastic x-ray scattering	| http://purl.org/pan-science/PaNET/PaNET01183 |
+ |   | PID.SAMPLE.PREFIX/desy_ds3 | resonant inelastic x-ray scattering	| http://purl.org/pan-science/PaNET/PaNET01183 |
+ |   | PID.SAMPLE.PREFIX/dls_ds1 | anomalous solution x-ray scattering	| http://purl.org/pan-science/PaNET/PaNET01275 |
+ |   | PID.SAMPLE.PREFIX/dls_ds2 | grazing incidence small angle x-ray scattering	| http://purl.org/pan-science/PaNET/PaNET01162 |
+ |   | PID.SAMPLE.PREFIX/hzdr_ds1 | inelastic x-ray small angle scattering	| http://purl.org/pan-science/PaNET/PaNET01281 |
+ |   | PID.SAMPLE.PREFIX/maxiv_ds1 | resonant inelastic x-ray scattering	 | http://purl.org/pan-science/PaNET/PaNET01183 |
+ |   | PID.SAMPLE.PREFIX/maxiv_ds2 | soft x-ray small angle scattering	 | http://purl.org/pan-science/PaNET/PaNET01282 |
+ |   | PID.SAMPLE.PREFIX/psi_ds1 | magnetic x-ray tomography	 | http://purl.org/pan-science/PaNET/PaNET01313 |
+ |   | PID.SAMPLE.PREFIX/psi_ds2 | magnetic x-ray tomography  | http://purl.org/pan-science/PaNET/PaNET01313 |
+ |   | PID.SAMPLE.PREFIX/psi_ds3 | magnetic x-ray tomography  | http://purl.org/pan-science/PaNET/PaNET01313 |
+ | Y | PID.SAMPLE.PREFIX/soleil_ds1 | **x-ray emission spectroscopy**  | **http://purl.org/pan-science/PaNET/PaNET01200** |
+ | Y | PID.SAMPLE.PREFIX/soleil_ds2 | **x-ray emission spectroscopy**  | **http://purl.org/pan-science/PaNET/PaNET01200** |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds1 | **x-ray emission spectroscopy** ,<br /> magnetic x-ray tomography | **http://purl.org/pan-science/PaNET/PaNET01200** ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds2 | **x-ray emission spectroscopy** ,<br /> magnetic x-ray tomography | **http://purl.org/pan-science/PaNET/PaNET01200** ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds3 | **x-ray emission spectroscopy** ,<br /> magnetic x-ray tomography | **http://purl.org/pan-science/PaNET/PaNET01200** ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds4 | **x-ray emission spectroscopy** ,<br /> magnetic x-ray tomography | **http://purl.org/pan-science/PaNET/PaNET01200** ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds5 | **x-ray emission spectroscopy** ,<br /> grazing incidence small angle scattering | **http://purl.org/pan-science/PaNET/PaNET01200** ,<br /> http://purl.org/pan-science/PaNET/PaNET01162 |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds6 | **x-ray emission spectroscopy** ,<br /> anomalous solution x-ray scattering | **http://purl.org/pan-science/PaNET/PaNET01200** ,<br /> http://purl.org/pan-science/PaNET/PaNET01275 |
+
+#### Status
+*verified* and *validated*
+
+
+### Query 2
+
+#### Use case:
+A user is searching for datasets tagged with technique *small angle scattering* or any of its descendants 
+
+#### User query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "name": "small angle scattering"
+        }
+      }
+    }
+  ,
+  ]
+}
+```
+
+Compact format:  
+```json
+{"include":[{"relation":"techniques","scope":{"where":{"name":"small angle scattering"}}}]}
+```
+Request URL:  
+`http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22name%22%3A%22small%20angle%20scattering%22%7D%7D%7D%5D%7D`
+
+Curl commnad
+```bash
+curl -X GET --header 'Accept: application/json' 'http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22name%22%3A%22small%20angle%20scattering%22%7D%7D%7D%5D%7D'
+```
+
+Equivalent user query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "name" : {"eq" : "small angle scattering"}
+        }
+      }
+    }
+  ]
+}
+
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "pid" : {"eq" : "http://purl.org/pan-science/PaNET/PaNET01124"}
+        }
+      }
+    }
+  ]
+}
+```
+
+Interpreted query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "pid": { "inq" : [
+            "http://purl.org/pan-science/PaNET/PaNET01124",
+            "http://purl.org/pan-science/PaNET/PaNET01127",
+            "http://purl.org/pan-science/PaNET/PaNET01189",
+            "http://purl.org/pan-science/PaNET/PaNET01277",
+            "http://purl.org/pan-science/PaNET/PaNET01099",
+            "http://purl.org/pan-science/PaNET/PaNET01276",
+            "http://purl.org/pan-science/PaNET/PaNET01133",
+            "http://purl.org/pan-science/PaNET/PaNET01278",
+            "http://purl.org/pan-science/PaNET/PaNET01274",
+            "http://purl.org/pan-science/PaNET/PaNET01275",
+            "http://purl.org/pan-science/PaNET/PaNET01188",
+            "http://purl.org/pan-science/PaNET/PaNET01282",
+            "http://purl.org/pan-science/PaNET/PaNET01281",
+            "http://purl.org/pan-science/PaNET/PaNET01273",
+            "http://purl.org/pan-science/PaNET/PaNET01279",
+            "http://purl.org/pan-science/PaNET/PaNET01280",
+            "http://purl.org/pan-science/PaNET/PaNET01107",
+            "http://purl.org/pan-science/PaNET/PaNET01162",
+            "http://purl.org/pan-science/PaNET/PaNET01286",
+            "http://purl.org/pan-science/PaNET/PaNET01287",
+            "http://purl.org/pan-science/PaNET/PaNET01241",
+            "http://purl.org/pan-science/PaNET/PaNET01240"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Dataset returned
+*PID.SAMPLE.PREFIX/dls_ds1 , PID.SAMPLE.PREFIX/dls_ds2 , PID.SAMPLE.PREFIX/hzdr_ds1 , PID.SAMPLE.PREFIX/maxiv_ds2 , PID.SAMPLE.PREFIX/ukri_ds5 , PID.SAMPLE.PREFIX/ukri_ds6*
+
+\
+Query details: 
+- techniques highlighted in **bold** are the techniques that match the query submitted
+ 
+ | Selected | Dataset id | Technique Name | Technique PID |
+ | :-: | - | - | - |
+ |   | PID.SAMPLE.PREFIX/desy_ds1 | resonant inelastic x-ray scattering | http://purl.org/pan-science/PaNET/PaNET01183 | 
+ |   | PID.SAMPLE.PREFIX/desy_ds2 | resonant inelastic x-ray scattering	| http://purl.org/pan-science/PaNET/PaNET01183 |
+ |   | PID.SAMPLE.PREFIX/desy_ds3 | resonant inelastic x-ray scattering	| http://purl.org/pan-science/PaNET/PaNET01183 |
+ | Y | PID.SAMPLE.PREFIX/dls_ds1 | **anomalous solution x-ray scattering**	| **http://purl.org/pan-science/PaNET/PaNET01275** |
+ | Y | PID.SAMPLE.PREFIX/dls_ds2 | **grazing incidence small angle x-ray scattering**	| **http://purl.org/pan-science/PaNET/PaNET01162** |
+ | Y | PID.SAMPLE.PREFIX/hzdr_ds1 | **inelastic x-ray small angle scattering**	| **http://purl.org/pan-science/PaNET/PaNET01281** |
+ |   | PID.SAMPLE.PREFIX/maxiv_ds1 | resonant inelastic x-ray scattering | http://purl.org/pan-science/PaNET/PaNET01183 |
+ | Y | PID.SAMPLE.PREFIX/maxiv_ds2 | **soft x-ray small angle scattering**	| **http://purl.org/pan-science/PaNET/PaNET01282** |
+ |   | PID.SAMPLE.PREFIX/psi_ds1 | magnetic x-ray tomography	 | http://purl.org/pan-science/PaNET/PaNET01313 |
+ |   | PID.SAMPLE.PREFIX/psi_ds2 | magnetic x-ray tomography  | http://purl.org/pan-science/PaNET/PaNET01313 |
+ |   | PID.SAMPLE.PREFIX/psi_ds3 | magnetic x-ray tomography  | http://purl.org/pan-science/PaNET/PaNET01313 |
+ |   | PID.SAMPLE.PREFIX/soleil_ds1 | x-ray emission spectroscopy  | http://purl.org/pan-science/PaNET/PaNET01200 |
+ |   | PID.SAMPLE.PREFIX/soleil_ds2 | x-ray emission spectroscopy  | http://purl.org/pan-science/PaNET/PaNET01200 |
+ |   | PID.SAMPLE.PREFIX/ukri_ds1 | x-ray emission spectroscopy ,<br /> magnetic x-ray tomography | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+ |   | PID.SAMPLE.PREFIX/ukri_ds2 | x-ray emission spectroscopy ,<br /> magnetic x-ray tomography | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+ |   | PID.SAMPLE.PREFIX/ukri_ds3 | x-ray emission spectroscopy ,<br /> magnetic x-ray tomography | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+ |   | PID.SAMPLE.PREFIX/ukri_ds4 | x-ray emission spectroscopy ,<br /> magnetic x-ray tomography | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds5 | x-ray emission spectroscopy ,<br /> **grazing incidence small angle scattering** | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> **http://purl.org/pan-science/PaNET/PaNET01162** |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds6 | x-ray emission spectroscopy ,<br /> **anomalous solution x-ray scattering** | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> **http://purl.org/pan-science/PaNET/PaNET01275** |
+
+
+#### Status
+*verified* and *validated*
+
+
+### Query 3
+
+#### Use case:
+A user is looking for datasets that are not tagged with the term *X-ray emission spectroscopy* or any of its descendants.
+
+#### User query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "name": {
+            "neq": "x-ray emission spectroscopy"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+Compact format:  
+```json
+{"include":[{"relation":"techniques","scope":{"where":{"name":{"neq":"x-ray emission spectroscopy"}}}}]}
+```
+
+Request URL:  
+`http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22name%22%3A%7B%22neq%22%3A%22x-ray%20emission%20spectroscopy%22%7D%7D%7D%7D%5D%7D`
+
+Curl commnad
+```bash
+curl -X GET --header 'Accept: application/json' 'http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22name%22%3A%7B%22neq%22%3A%22x-ray%20emission%20spectroscopy%22%7D%7D%7D%7D%5D%7D'
+```
+
+Equivalent user query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "pid" : {"neq" : "http://purl.org/pan-science/PaNET/PaNET01124"}
+        }
+      }
+    }
+  ]
+}
+```
+
+Interpreted query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "pid": { "nin" : [
+            "http://purl.org/pan-science/PaNET/PaNET01200"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Dataset returned
+*PID.SAMPLE.PREFIX/desy_ds1 , PID.SAMPLE.PREFIX/desy_ds2 , PID.SAMPLE.PREFIX/desy_ds3 , PID.SAMPLE.PREFIX/dls_ds1 , PID.SAMPLE.PREFIX/dls_ds2 , PID.SAMPLE.PREFIX/hzdr_ds1 , PID.SAMPLE.PREFIX/maxiv_ds1 , PID.SAMPLE.PREFIX/maxiv_ds2 , PID.SAMPLE.PREFIX/psi_ds1 , PID.SAMPLE.PREFIX/psi_ds2 , PID.SAMPLE.PREFIX/psi_ds3*
+
+\
+Query details: 
+- techniques highlighted with ~~strikethrough~~ are the ones specified in the query which should not be present for the dataset to be selected
+
+ 
+ | Selected | Dataset id | Technique Name | Technique PID |
+ | :-: | - | - | - |
+ | Y | PID.SAMPLE.PREFIX/desy_ds1 | resonant inelastic x-ray scattering | http://purl.org/pan-science/PaNET/PaNET01183 | 
+ | Y | PID.SAMPLE.PREFIX/desy_ds2 | resonant inelastic x-ray scattering	| http://purl.org/pan-science/PaNET/PaNET01183 |
+ | Y | PID.SAMPLE.PREFIX/desy_ds3 | resonant inelastic x-ray scattering	| http://purl.org/pan-science/PaNET/PaNET01183 |
+ | Y | PID.SAMPLE.PREFIX/dls_ds1 | anomalous solution x-ray scattering	| http://purl.org/pan-science/PaNET/PaNET01275 |
+ | Y | PID.SAMPLE.PREFIX/dls_ds2 | grazing incidence small angle x-ray scattering	| http://purl.org/pan-science/PaNET/PaNET01162 |
+ | Y | PID.SAMPLE.PREFIX/hzdr_ds1 | inelastic x-ray small angle scattering	| http://purl.org/pan-science/PaNET/PaNET01281 |
+ | Y | PID.SAMPLE.PREFIX/maxiv_ds1 | resonant inelastic x-ray scattering | http://purl.org/pan-science/PaNET/PaNET01183 |
+ | Y | PID.SAMPLE.PREFIX/maxiv_ds2 | soft x-ray small angle scattering	| http://purl.org/pan-science/PaNET/PaNET01282 |
+ | Y | PID.SAMPLE.PREFIX/psi_ds1 | magnetic x-ray tomography	 | http://purl.org/pan-science/PaNET/PaNET01313 |
+ | Y | PID.SAMPLE.PREFIX/psi_ds2 | magnetic x-ray tomography  | http://purl.org/pan-science/PaNET/PaNET01313 |
+ | Y | PID.SAMPLE.PREFIX/psi_ds3 | magnetic x-ray tomography  | http://purl.org/pan-science/PaNET/PaNET01313 |
+ |   | PID.SAMPLE.PREFIX/soleil_ds1 | ~~x-ray emission spectroscopy~~  | ~~http://purl.org/pan-science/PaNET/PaNET01200~~ |
+ |   | PID.SAMPLE.PREFIX/soleil_ds2 | ~~x-ray emission spectroscopy~~  | ~~http://purl.org/pan-science/PaNET/PaNET01200~~ |
+ |   | PID.SAMPLE.PREFIX/ukri_ds1 | ~~x-ray emission spectroscopy~~ ,<br /> magnetic x-ray tomography | ~~http://purl.org/pan-science/PaNET/PaNET01200~~ ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+ |   | PID.SAMPLE.PREFIX/ukri_ds2 | ~~x-ray emission spectroscopy~~ ,<br /> magnetic x-ray tomography | ~~http://purl.org/pan-science/PaNET/PaNET01200~~ ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+ |   | PID.SAMPLE.PREFIX/ukri_ds3 | ~~x-ray emission spectroscopy~~ ,<br /> magnetic x-ray tomography | ~~http://purl.org/pan-science/PaNET/PaNET01200~~ ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+ |   | PID.SAMPLE.PREFIX/ukri_ds4 | ~~x-ray emission spectroscopy~~ ,<br /> magnetic x-ray tomography | ~~http://purl.org/pan-science/PaNET/PaNET01200~~ ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+ |   | PID.SAMPLE.PREFIX/ukri_ds5 | ~~x-ray emission spectroscopy~~ ,<br /> grazing incidence small angle scattering | ~~http://purl.org/pan-science/PaNET/PaNET01200~~ ,<br /> http://purl.org/pan-science/PaNET/PaNET01162 |
+ |   | PID.SAMPLE.PREFIX/ukri_ds6 | ~~x-ray emission spectroscopy~~ ,<br /> anomalous solution x-ray scattering | ~~http://purl.org/pan-science/PaNET/PaNET01200~~ ,<br /> http://purl.org/pan-science/PaNET/PaNET01275 |
+
+
+#### Status
+*verified* and *validated*
+
+
+### Query 4
+
+#### Use case:
+A user is looking for datasets that are not tagged with the term *small angle scattering* or any of its descendants.
+
+#### User query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "name": {
+            "neq": "small angle scattering"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+Compact format:  
+```json
+{"include":[{"relation":"techniques","scope":{"where":{"name":{"neq":"small angle scattering"}}}}]}
+```
+
+Request URL:  
+`http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22name%22%3A%7B%22neq%22%3A%22small%20angle%20scattering%22%7D%7D%7D%7D%5D%7D`
+
+Curl commnad
+```bash
+curl -X GET --header 'Accept: application/json' 'http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22name%22%3A%7B%22neq%22%3A%22small%20angle%20scattering%22%7D%7D%7D%7D%5D%7D'
+```
+
+Equivalent user query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "pid" : {"neq" : "http://purl.org/pan-science/PaNET/PaNET01124"}
+        }
+      }
+    }
+  ]
+}
+```
+
+Interpreted query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "pid": { "nin" : [
+            "http://purl.org/pan-science/PaNET/PaNET01124",
+            "http://purl.org/pan-science/PaNET/PaNET01127",
+            "http://purl.org/pan-science/PaNET/PaNET01189",
+            "http://purl.org/pan-science/PaNET/PaNET01277",
+            "http://purl.org/pan-science/PaNET/PaNET01099",
+            "http://purl.org/pan-science/PaNET/PaNET01276",
+            "http://purl.org/pan-science/PaNET/PaNET01133",
+            "http://purl.org/pan-science/PaNET/PaNET01278",
+            "http://purl.org/pan-science/PaNET/PaNET01274",
+            "http://purl.org/pan-science/PaNET/PaNET01275",
+            "http://purl.org/pan-science/PaNET/PaNET01188",
+            "http://purl.org/pan-science/PaNET/PaNET01282",
+            "http://purl.org/pan-science/PaNET/PaNET01281",
+            "http://purl.org/pan-science/PaNET/PaNET01273",
+            "http://purl.org/pan-science/PaNET/PaNET01279",
+            "http://purl.org/pan-science/PaNET/PaNET01280",
+            "http://purl.org/pan-science/PaNET/PaNET01107",
+            "http://purl.org/pan-science/PaNET/PaNET01162",
+            "http://purl.org/pan-science/PaNET/PaNET01286",
+            "http://purl.org/pan-science/PaNET/PaNET01287",
+            "http://purl.org/pan-science/PaNET/PaNET01241",
+            "http://purl.org/pan-science/PaNET/PaNET01240"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Dataset returned
+*PID.SAMPLE.PREFIX/desy_ds1 , PID.SAMPLE.PREFIX/desy_ds2 , PID.SAMPLE.PREFIX/desy_ds3 , PID.SAMPLE.PREFIX/maxiv_ds1 , PID.SAMPLE.PREFIX/psi_ds1 , PID.SAMPLE.PREFIX/psi_ds2 , PID.SAMPLE.PREFIX/psi_ds3 , PID.SAMPLE.PREFIX/soleil_ds1 , PID.SAMPLE.PREFIX/soleil_ds2 , PID.SAMPLE.PREFIX/ukri_ds1 , PID.SAMPLE.PREFIX/ukri_ds2 , PID.SAMPLE.PREFIX/ukri_ds3 , PID.SAMPLE.PREFIX/ukri_ds4*
+
+\
+Query details: 
+- techniques highlighted with ~~strikethrough~~ are the ones specified in the query which should not be present for the dataset to be selected
+
+ 
+ | Selected | Dataset id | Technique Name | Technique PID |
+ | :-: | - | - | - |
+ | Y | PID.SAMPLE.PREFIX/desy_ds1 | resonant inelastic x-ray scattering | http://purl.org/pan-science/PaNET/PaNET01183 | 
+ | Y | PID.SAMPLE.PREFIX/desy_ds2 | resonant inelastic x-ray scattering	| http://purl.org/pan-science/PaNET/PaNET01183 |
+ | Y | PID.SAMPLE.PREFIX/desy_ds3 | resonant inelastic x-ray scattering	| http://purl.org/pan-science/PaNET/PaNET01183 |
+ |   | PID.SAMPLE.PREFIX/dls_ds1 | ~~anomalous solution x-ray scattering~~	| ~~http://purl.org/pan-science/PaNET/PaNET01275~~ |
+ |   | PID.SAMPLE.PREFIX/dls_ds2 | ~~grazing incidence small angle x-ray scattering~~	| ~~http://purl.org/pan-science/PaNET/PaNET01162~~ |
+ |   | PID.SAMPLE.PREFIX/hzdr_ds1 | ~~inelastic x-ray small angle scattering~~	| ~~http://purl.org/pan-science/PaNET/PaNET01281~~ |
+ | Y | PID.SAMPLE.PREFIX/maxiv_ds1 | resonant inelastic x-ray scattering | http://purl.org/pan-science/PaNET/PaNET01183 |
+ |   | PID.SAMPLE.PREFIX/maxiv_ds2 | ~~soft x-ray small angle scattering~~	| ~~http://purl.org/pan-science/PaNET/PaNET01282~~ |
+ | Y | PID.SAMPLE.PREFIX/psi_ds1 | magnetic x-ray tomography	 | http://purl.org/pan-science/PaNET/PaNET01313 |
+ | Y | PID.SAMPLE.PREFIX/psi_ds2 | magnetic x-ray tomography  | http://purl.org/pan-science/PaNET/PaNET01313 |
+ | Y | PID.SAMPLE.PREFIX/psi_ds3 | magnetic x-ray tomography  | http://purl.org/pan-science/PaNET/PaNET01313 |
+ | Y | PID.SAMPLE.PREFIX/soleil_ds1 | x-ray emission spectroscopy  | http://purl.org/pan-science/PaNET/PaNET01200 |
+ | Y | PID.SAMPLE.PREFIX/soleil_ds2 | x-ray emission spectroscopy  | http://purl.org/pan-science/PaNET/PaNET01200 |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds1 | x-ray emission spectroscopy ,<br /> magnetic x-ray tomography | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds2 | x-ray emission spectroscopy ,<br /> magnetic x-ray tomography | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds3 | x-ray emission spectroscopy ,<br /> magnetic x-ray tomography | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds4 | x-ray emission spectroscopy ,<br /> magnetic x-ray tomography | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> http://purl.org/pan-science/PaNET/PaNET01313 |
+ |   | PID.SAMPLE.PREFIX/ukri_ds5 | x-ray emission spectroscopy ,<br /> ~~grazing incidence small angle scattering~~ | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> ~~http://purl.org/pan-science/PaNET/PaNET01162~~ |
+ |   | PID.SAMPLE.PREFIX/ukri_ds6 | x-ray emission spectroscopy ,<br /> ~~anomalous solution x-ray scattering~~ | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> ~~http://purl.org/pan-science/PaNET/PaNET01275~~ |
+
+
+#### Status
+*verified* and *validated*
+
+
+### Query 5
+
+#### Use case:
+A user is searching for datasets tagged with both techniques *small angle scattering* and *magnetism technique* or any of their descendants 
+
+#### User query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and": [
+            {
+              "name": "small angle scattering"
+            },
+            {
+              "name": "magnetism technique"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+Compact format:  
+```json
+{"include":[{"relation":"techniques","scope":{"where":{"and":[{"name":"small angle scattering"},{"name": "magnetism technique"}]}}}]}
+```
+
+Request URL:  
+`http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22and%22%3A%5B%7B%22name%22%3A%22small%20angle%20scattering%22%7D%2C%7B%22name%22%3A%20%22magnetism%20technique%22%7D%5D%7D%7D%7D%5D%7D`
+
+Curl commnad
+```bash
+curl -X GET --header 'Accept: application/json' 'http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22and%22%3A%5B%7B%22name%22%3A%22small%20angle%20scattering%22%7D%2C%7B%22name%22%3A%20%22magnetism%20technique%22%7D%5D%7D%7D%7D%5D%7D'
+```
+
+Equivalent user query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and": [
+            {
+              "name": {
+                "eq" : "small angle scattering"
+              }
+            },
+            {
+              "name": {
+                "eq" : "magnetism technique"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+
+
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and" : [
+            {
+              "pid" : "http://purl.org/pan-science/PaNET/PaNET01124"
+            },
+            {
+              "pid" : "http://purl.org/pan-science/PaNET/PaNET00207"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and" : [
+            {
+              "pid" : {
+                "eq" : "http://purl.org/pan-science/PaNET/PaNET01124"
+              }
+            },
+            {
+              "pid" : {
+                "eq" : "http://purl.org/pan-science/PaNET/PaNET00207"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+Interpreted query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and":[
+            {
+              "pid" : {
+                "inq" : [
+                  "http://purl.org/pan-science/PaNET/PaNET01124",
+                  "http://purl.org/pan-science/PaNET/PaNET01127",
+                  "http://purl.org/pan-science/PaNET/PaNET01189",
+                  "http://purl.org/pan-science/PaNET/PaNET01277",
+                  "http://purl.org/pan-science/PaNET/PaNET01099",
+                  "http://purl.org/pan-science/PaNET/PaNET01276",
+                  "http://purl.org/pan-science/PaNET/PaNET01133",
+                  "http://purl.org/pan-science/PaNET/PaNET01278",
+                  "http://purl.org/pan-science/PaNET/PaNET01274",
+                  "http://purl.org/pan-science/PaNET/PaNET01275",
+                  "http://purl.org/pan-science/PaNET/PaNET01188",
+                  "http://purl.org/pan-science/PaNET/PaNET01282",
+                  "http://purl.org/pan-science/PaNET/PaNET01281",
+                  "http://purl.org/pan-science/PaNET/PaNET01273",
+                  "http://purl.org/pan-science/PaNET/PaNET01279",
+                  "http://purl.org/pan-science/PaNET/PaNET01280",
+                  "http://purl.org/pan-science/PaNET/PaNET01107",
+                  "http://purl.org/pan-science/PaNET/PaNET01162",
+                  "http://purl.org/pan-science/PaNET/PaNET01286",
+                  "http://purl.org/pan-science/PaNET/PaNET01287",
+                  "http://purl.org/pan-science/PaNET/PaNET01241",
+                  "http://purl.org/pan-science/PaNET/PaNET01240"
+                ]
+              }
+            },
+            {
+              "pid" : {
+                "inq" : [
+                  "http://purl.org/pan-science/PaNET/PaNET00207",
+                  "http://purl.org/pan-science/PaNET/PaNET01313",
+                  "http://purl.org/pan-science/PaNET/PaNET01143",
+                  "http://purl.org/pan-science/PaNET/PaNET01301",
+                  "http://purl.org/pan-science/PaNET/PaNET01137",
+                  "http://purl.org/pan-science/PaNET/PaNET01221",
+                  "http://purl.org/pan-science/PaNET/PaNET01142",
+                  "http://purl.org/pan-science/PaNET/PaNET01259",
+                  "http://purl.org/pan-science/PaNET/PaNET01252",
+                  "http://purl.org/pan-science/PaNET/PaNET01141",
+                  "http://purl.org/pan-science/PaNET/PaNET01253"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Dataset returned
+No dataset is returned.
+
+\
+Query details: 
+- techniques highlighted with **bold** are the ones matching the first operand of the and in the query, 
+- techniques highlighted with *italic* are the ones matching the second operand of the and in the query, 
+- there is no datasets where both techniques are higlighted
+
+ 
+ | Selected | Dataset id | Technique Name | Technique PID |
+ | :-: | - | - | - |
+ |   | PID.SAMPLE.PREFIX/desy_ds1 | resonant inelastic x-ray scattering | http://purl.org/pan-science/PaNET/PaNET01183 | 
+ |   | PID.SAMPLE.PREFIX/desy_ds2 | resonant inelastic x-ray scattering	| http://purl.org/pan-science/PaNET/PaNET01183 |
+ |   | PID.SAMPLE.PREFIX/desy_ds3 | resonant inelastic x-ray scattering	| http://purl.org/pan-science/PaNET/PaNET01183 |
+ |   | PID.SAMPLE.PREFIX/dls_ds1 | **anomalous solution x-ray scattering**	| **http://purl.org/pan-science/PaNET/PaNET01275** |
+ |   | PID.SAMPLE.PREFIX/dls_ds2 | **grazing incidence small angle x-ray scattering**	| **http://purl.org/pan-science/PaNET/PaNET01162** |
+ |   | PID.SAMPLE.PREFIX/hzdr_ds1 | **inelastic x-ray small angle scattering**	| **http://purl.org/pan-science/PaNET/PaNET01281** |
+ |   | PID.SAMPLE.PREFIX/maxiv_ds1 | resonant inelastic x-ray scattering | http://purl.org/pan-science/PaNET/PaNET01183 |
+ |   | PID.SAMPLE.PREFIX/maxiv_ds2 | **soft x-ray small angle scattering**	| **http://purl.org/pan-science/PaNET/PaNET01282** |
+ |   | PID.SAMPLE.PREFIX/psi_ds1 | *magnetic x-ray tomography*	| *http://purl.org/pan-science/PaNET/PaNET01313* |
+ |   | PID.SAMPLE.PREFIX/psi_ds2 | *magnetic x-ray tomography*  | *http://purl.org/pan-science/PaNET/PaNET01313* |
+ |   | PID.SAMPLE.PREFIX/psi_ds3 | *magnetic x-ray tomography*  | *http://purl.org/pan-science/PaNET/PaNET01313* |
+ |   | PID.SAMPLE.PREFIX/soleil_ds1 | x-ray emission spectroscopy  | http://purl.org/pan-science/PaNET/PaNET01200 |
+ |   | PID.SAMPLE.PREFIX/soleil_ds2 | x-ray emission spectroscopy  | http://purl.org/pan-science/PaNET/PaNET01200 |
+ |   | PID.SAMPLE.PREFIX/ukri_ds1 | x-ray emission spectroscopy ,<br /> *magnetic x-ray tomography* | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> *http://purl.org/pan-science/PaNET/PaNET01313* |
+ |   | PID.SAMPLE.PREFIX/ukri_ds2 | x-ray emission spectroscopy ,<br /> *magnetic x-ray tomography* | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> *http://purl.org/pan-science/PaNET/PaNET01313* |
+ |   | PID.SAMPLE.PREFIX/ukri_ds3 | x-ray emission spectroscopy ,<br /> *magnetic x-ray tomography* | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> *http://purl.org/pan-science/PaNET/PaNET01313* |
+ |   | PID.SAMPLE.PREFIX/ukri_ds4 | x-ray emission spectroscopy ,<br /> *magnetic x-ray tomography* | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> *http://purl.org/pan-science/PaNET/PaNET01313* |
+ |   | PID.SAMPLE.PREFIX/ukri_ds5 | x-ray emission spectroscopy ,<br /> **grazing incidence small angle scattering** | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> **http://purl.org/pan-science/PaNET/PaNET01162** |
+ |   | PID.SAMPLE.PREFIX/ukri_ds6 | x-ray emission spectroscopy ,<br /> **anomalous solution x-ray scattering** | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> **http://purl.org/pan-science/PaNET/PaNET01275** |
+
+
+#### Status
+*verified* and *validated*
+
+
+### Query 6
+
+#### Use case:
+A user is searching for datasets tagged with both techniques *small angle scattering* or *magnetism technique* or any of their descendants 
+
+#### User query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "or": [
+            {
+              "name": "small angle scattering"
+            },
+            {
+              "name": "magnetism technique"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+Compact format:  
+```json
+{"include":[{"relation":"techniques","scope":{"where":{"or":[{"name":"small angle scattering"},{"name": "magnetism technique"}]}}}]}
+```
+
+Request URL:  
+`http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22or%22%3A%5B%7B%22name%22%3A%22small%20angle%20scattering%22%7D%2C%7B%22name%22%3A%20%22magnetism%20technique%22%7D%5D%7D%7D%7D%5D%7D`
+
+Curl commnad
+```bash
+curl -X GET --header 'Accept: application/json' 'http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22or%22%3A%5B%7B%22name%22%3A%22small%20angle%20scattering%22%7D%2C%7B%22name%22%3A%20%22magnetism%20technique%22%7D%5D%7D%7D%7D%5D%7D'
+```
+
+Equivalent user query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "or": [
+            {
+              "name": {
+                "eq" : "small angle scattering"
+              }
+            },
+            {
+              "name": {
+                "eq" : "magnetism technique"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+
+
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "or" : [
+            {
+              "pid" : "http://purl.org/pan-science/PaNET/PaNET01124"
+            },
+            {
+              "pid" : "http://purl.org/pan-science/PaNET/PaNET00207"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "or" : [
+            {
+              "pid" : {
+                "eq" : "http://purl.org/pan-science/PaNET/PaNET01124"
+              }
+            },
+            {
+              "pid" : {
+                "eq" : "http://purl.org/pan-science/PaNET/PaNET00207"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+Interpreted query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "or":[
+            {
+              "pid" : {
+                "inq" : [
+                  "http://purl.org/pan-science/PaNET/PaNET01124",
+                  "http://purl.org/pan-science/PaNET/PaNET01127",
+                  "http://purl.org/pan-science/PaNET/PaNET01189",
+                  "http://purl.org/pan-science/PaNET/PaNET01277",
+                  "http://purl.org/pan-science/PaNET/PaNET01099",
+                  "http://purl.org/pan-science/PaNET/PaNET01276",
+                  "http://purl.org/pan-science/PaNET/PaNET01133",
+                  "http://purl.org/pan-science/PaNET/PaNET01278",
+                  "http://purl.org/pan-science/PaNET/PaNET01274",
+                  "http://purl.org/pan-science/PaNET/PaNET01275",
+                  "http://purl.org/pan-science/PaNET/PaNET01188",
+                  "http://purl.org/pan-science/PaNET/PaNET01282",
+                  "http://purl.org/pan-science/PaNET/PaNET01281",
+                  "http://purl.org/pan-science/PaNET/PaNET01273",
+                  "http://purl.org/pan-science/PaNET/PaNET01279",
+                  "http://purl.org/pan-science/PaNET/PaNET01280",
+                  "http://purl.org/pan-science/PaNET/PaNET01107",
+                  "http://purl.org/pan-science/PaNET/PaNET01162",
+                  "http://purl.org/pan-science/PaNET/PaNET01286",
+                  "http://purl.org/pan-science/PaNET/PaNET01287",
+                  "http://purl.org/pan-science/PaNET/PaNET01241",
+                  "http://purl.org/pan-science/PaNET/PaNET01240"
+                ]
+              }
+            },
+            {
+              "pid" : {
+                "inq" : [
+                  "http://purl.org/pan-science/PaNET/PaNET00207",
+                  "http://purl.org/pan-science/PaNET/PaNET01313",
+                  "http://purl.org/pan-science/PaNET/PaNET01143",
+                  "http://purl.org/pan-science/PaNET/PaNET01301",
+                  "http://purl.org/pan-science/PaNET/PaNET01137",
+                  "http://purl.org/pan-science/PaNET/PaNET01221",
+                  "http://purl.org/pan-science/PaNET/PaNET01142",
+                  "http://purl.org/pan-science/PaNET/PaNET01259",
+                  "http://purl.org/pan-science/PaNET/PaNET01252",
+                  "http://purl.org/pan-science/PaNET/PaNET01141",
+                  "http://purl.org/pan-science/PaNET/PaNET01253"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Dataset returned
+*PID.SAMPLE.PREFIX/dls_ds1 , PID.SAMPLE.PREFIX/dls_ds2 , PID.SAMPLE.PREFIX/hzdr_ds1 , PID.SAMPLE.PREFIX/maxiv_ds2 , PID.SAMPLE.PREFIX/psi_ds1 , PID.SAMPLE.PREFIX/psi_ds2 , PID.SAMPLE.PREFIX/psi_ds3 , PID.SAMPLE.PREFIX/ukri_ds1 , PID.SAMPLE.PREFIX/ukri_ds2 , PID.SAMPLE.PREFIX/ukri_ds3 , PID.SAMPLE.PREFIX/ukri_ds4 , PID.SAMPLE.PREFIX/ukri_ds5 , PID.SAMPLE.PREFIX/ukri_ds6*
+
+
+\
+Query details: 
+- techniques highlighted with **bold** are the ones matching the first operand of the and in the query, 
+- techniques highlighted with *italic* are the ones matching the second operand of the and in the query, 
+
+ 
+ | Selected | Dataset id | Technique Name | Technique PID |
+ | :-: | - | - | - |
+ |   | PID.SAMPLE.PREFIX/desy_ds1 | resonant inelastic x-ray scattering | http://purl.org/pan-science/PaNET/PaNET01183 | 
+ |   | PID.SAMPLE.PREFIX/desy_ds2 | resonant inelastic x-ray scattering	| http://purl.org/pan-science/PaNET/PaNET01183 |
+ |   | PID.SAMPLE.PREFIX/desy_ds3 | resonant inelastic x-ray scattering	| http://purl.org/pan-science/PaNET/PaNET01183 |
+ | Y | PID.SAMPLE.PREFIX/dls_ds1 | **anomalous solution x-ray scattering**	| **http://purl.org/pan-science/PaNET/PaNET01275** |
+ | Y | PID.SAMPLE.PREFIX/dls_ds2 | **grazing incidence small angle x-ray scattering**	| **http://purl.org/pan-science/PaNET/PaNET01162** |
+ | Y | PID.SAMPLE.PREFIX/hzdr_ds1 | **inelastic x-ray small angle scattering**	| **http://purl.org/pan-science/PaNET/PaNET01281** |
+ |   | PID.SAMPLE.PREFIX/maxiv_ds1 | resonant inelastic x-ray scattering | http://purl.org/pan-science/PaNET/PaNET01183 |
+ | Y | PID.SAMPLE.PREFIX/maxiv_ds2 | **soft x-ray small angle scattering**	| **http://purl.org/pan-science/PaNET/PaNET01282** |
+ | Y | PID.SAMPLE.PREFIX/psi_ds1 | *magnetic x-ray tomography*	| *http://purl.org/pan-science/PaNET/PaNET01313* |
+ | Y | PID.SAMPLE.PREFIX/psi_ds2 | *magnetic x-ray tomography*  | *http://purl.org/pan-science/PaNET/PaNET01313* |
+ | Y | PID.SAMPLE.PREFIX/psi_ds3 | *magnetic x-ray tomography*  | *http://purl.org/pan-science/PaNET/PaNET01313* |
+ |   | PID.SAMPLE.PREFIX/soleil_ds1 | x-ray emission spectroscopy  | http://purl.org/pan-science/PaNET/PaNET01200 |
+ |   | PID.SAMPLE.PREFIX/soleil_ds2 | x-ray emission spectroscopy  | http://purl.org/pan-science/PaNET/PaNET01200 |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds1 | x-ray emission spectroscopy ,<br /> *magnetic x-ray tomography* | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> *http://purl.org/pan-science/PaNET/PaNET01313* |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds2 | x-ray emission spectroscopy ,<br /> *magnetic x-ray tomography* | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> *http://purl.org/pan-science/PaNET/PaNET01313* |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds3 | x-ray emission spectroscopy ,<br /> *magnetic x-ray tomography* | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> *http://purl.org/pan-science/PaNET/PaNET01313* |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds4 | x-ray emission spectroscopy ,<br /> *magnetic x-ray tomography* | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> *http://purl.org/pan-science/PaNET/PaNET01313* |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds5 | x-ray emission spectroscopy ,<br /> **grazing incidence small angle scattering** | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> **http://purl.org/pan-science/PaNET/PaNET01162** |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds6 | x-ray emission spectroscopy ,<br /> **anomalous solution x-ray scattering** | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> **http://purl.org/pan-science/PaNET/PaNET01275** |
+
+
+#### Status
+*verified* and *validated*
+
+
+### Query 7
+
+#### Use case:
+A user is searching for datasets tagged with both techniques *small angle scattering* and *x-ray probe* or any of their descendants 
+
+#### User query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and": [
+            {
+              "name": "small angle scattering"
+            },
+            {
+              "name": "x-ray probe"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+Compact format:  
+```json
+{"include":[{"relation":"techniques","scope":{"where":{"and":[{"name":"small angle scattering"},{"name": "x-ray probe"}]}}}]}
+```
+
+Request URL:  
+`http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22and%22%3A%5B%7B%22name%22%3A%22small%20angle%20scattering%22%7D%2C%7B%22name%22%3A%20%22x-ray%20probe%22%7D%5D%7D%7D%7D%5D%7D`
+
+Curl commnad
+```bash
+curl -X GET --header 'Accept: application/json' 'http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22and%22%3A%5B%7B%22name%22%3A%22small%20angle%20scattering%22%7D%2C%7B%22name%22%3A%20%22x-ray%20probe%22%7D%5D%7D%7D%7D%5D%7D'
+```
+
+Equivalent user query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and": [
+            {
+              "name": {
+                "eq" : "small angle scattering"
+              }
+            },
+            {
+              "name": {
+                "eq" : "x-ray probe"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+
+
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and" : [
+            {
+              "pid" : "http://purl.org/pan-science/PaNET/PaNET01124"
+            },
+            {
+              "pid" : "http://purl.org/pan-science/PaNET/PaNET01012"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and" : [
+            {
+              "pid" : {
+                "eq" : "http://purl.org/pan-science/PaNET/PaNET01124"
+              }
+            },
+            {
+              "pid" : {
+                "eq" : "http://purl.org/pan-science/PaNET/PaNET01012"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+Interpreted query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and":[
+            {
+              "pid" : {
+                "inq" : [
+                  "http://purl.org/pan-science/PaNET/PaNET01124",
+                  "http://purl.org/pan-science/PaNET/PaNET01127",
+                  "http://purl.org/pan-science/PaNET/PaNET01189",
+                  "http://purl.org/pan-science/PaNET/PaNET01277",
+                  "http://purl.org/pan-science/PaNET/PaNET01099",
+                  "http://purl.org/pan-science/PaNET/PaNET01276",
+                  "http://purl.org/pan-science/PaNET/PaNET01133",
+                  "http://purl.org/pan-science/PaNET/PaNET01278",
+                  "http://purl.org/pan-science/PaNET/PaNET01274",
+                  "http://purl.org/pan-science/PaNET/PaNET01275",
+                  "http://purl.org/pan-science/PaNET/PaNET01188",
+                  "http://purl.org/pan-science/PaNET/PaNET01282",
+                  "http://purl.org/pan-science/PaNET/PaNET01281",
+                  "http://purl.org/pan-science/PaNET/PaNET01273",
+                  "http://purl.org/pan-science/PaNET/PaNET01279",
+                  "http://purl.org/pan-science/PaNET/PaNET01280",
+                  "http://purl.org/pan-science/PaNET/PaNET01107",
+                  "http://purl.org/pan-science/PaNET/PaNET01162",
+                  "http://purl.org/pan-science/PaNET/PaNET01286",
+                  "http://purl.org/pan-science/PaNET/PaNET01287",
+                  "http://purl.org/pan-science/PaNET/PaNET01241",
+                  "http://purl.org/pan-science/PaNET/PaNET01240"
+                ]
+              }
+            },
+            {
+              "pid" : {
+                "inq" : [
+                  "http://purl.org/pan-science/PaNET/PaNET01012",
+                  "http://purl.org/pan-science/PaNET/PaNET01161",
+                  "http://purl.org/pan-science/PaNET/PaNET01290",
+                  "http://purl.org/pan-science/PaNET/PaNET01208",
+                  "http://purl.org/pan-science/PaNET/PaNET01219",
+                  "http://purl.org/pan-science/PaNET/PaNET01102",
+                  "http://purl.org/pan-science/PaNET/PaNET01168",
+                  "http://purl.org/pan-science/PaNET/PaNET01309",
+                  "http://purl.org/pan-science/PaNET/PaNET01184",
+                  "http://purl.org/pan-science/PaNET/PaNET01271",
+                  "http://purl.org/pan-science/PaNET/PaNET01306",
+                  "http://purl.org/pan-science/PaNET/PaNET01014",
+                  "http://purl.org/pan-science/PaNET/PaNET01305",
+                  "http://purl.org/pan-science/PaNET/PaNET01216",
+                  "http://purl.org/pan-science/PaNET/PaNET01227",
+                  "http://purl.org/pan-science/PaNET/PaNET01204",
+                  "http://purl.org/pan-science/PaNET/PaNET01218",
+                  "http://purl.org/pan-science/PaNET/PaNET01156",
+                  "http://purl.org/pan-science/PaNET/PaNET01229",
+                  "http://purl.org/pan-science/PaNET/PaNET01272",
+                  "http://purl.org/pan-science/PaNET/PaNET01307",
+                  "http://purl.org/pan-science/PaNET/PaNET01266",
+                  "http://purl.org/pan-science/PaNET/PaNET01303",
+                  "http://purl.org/pan-science/PaNET/PaNET01095",
+                  "http://purl.org/pan-science/PaNET/PaNET01200",
+                  "http://purl.org/pan-science/PaNET/PaNET01207",
+                  "http://purl.org/pan-science/PaNET/PaNET01313",
+                  "http://purl.org/pan-science/PaNET/PaNET01186",
+                  "http://purl.org/pan-science/PaNET/PaNET01187",
+                  "http://purl.org/pan-science/PaNET/PaNET01015",
+                  "http://purl.org/pan-science/PaNET/PaNET01302",
+                  "http://purl.org/pan-science/PaNET/PaNET01180",
+                  "http://purl.org/pan-science/PaNET/PaNET01314",
+                  "http://purl.org/pan-science/PaNET/PaNET01224",
+                  "http://purl.org/pan-science/PaNET/PaNET01191",
+                  "http://purl.org/pan-science/PaNET/PaNET01316",
+                  "http://purl.org/pan-science/PaNET/PaNET01315",
+                  "http://purl.org/pan-science/PaNET/PaNET01169",
+                  "http://purl.org/pan-science/PaNET/PaNET01312",
+                  "http://purl.org/pan-science/PaNET/PaNET01301",
+                  "http://purl.org/pan-science/PaNET/PaNET01311",
+                  "http://purl.org/pan-science/PaNET/PaNET01262",
+                  "http://purl.org/pan-science/PaNET/PaNET01261",
+                  "http://purl.org/pan-science/PaNET/PaNET01284",
+                  "http://purl.org/pan-science/PaNET/PaNET01167",
+                  "http://purl.org/pan-science/PaNET/PaNET01182",
+                  "http://purl.org/pan-science/PaNET/PaNET01183",
+                  "http://purl.org/pan-science/PaNET/PaNET01172",
+                  "http://purl.org/pan-science/PaNET/PaNET01310",
+                  "http://purl.org/pan-science/PaNET/PaNET01137",
+                  "http://purl.org/pan-science/PaNET/PaNET01221",
+                  "http://purl.org/pan-science/PaNET/PaNET01274",
+                  "http://purl.org/pan-science/PaNET/PaNET01275",
+                  "http://purl.org/pan-science/PaNET/PaNET01283",
+                  "http://purl.org/pan-science/PaNET/PaNET01188",
+                  "http://purl.org/pan-science/PaNET/PaNET01282",
+                  "http://purl.org/pan-science/PaNET/PaNET01260",
+                  "http://purl.org/pan-science/PaNET/PaNET01281",
+                  "http://purl.org/pan-science/PaNET/PaNET01280",
+                  "http://purl.org/pan-science/PaNET/PaNET01149",
+                  "http://purl.org/pan-science/PaNET/PaNET01013",
+                  "http://purl.org/pan-science/PaNET/PaNET01103",
+                  "http://purl.org/pan-science/PaNET/PaNET01300",
+                  "http://purl.org/pan-science/PaNET/PaNET01327",
+                  "http://purl.org/pan-science/PaNET/PaNET01205",
+                  "http://purl.org/pan-science/PaNET/PaNET01238",
+                  "http://purl.org/pan-science/PaNET/PaNET01196",
+                  "http://purl.org/pan-science/PaNET/PaNET01197",
+                  "http://purl.org/pan-science/PaNET/PaNET01199",
+                  "http://purl.org/pan-science/PaNET/PaNET01259",
+                  "http://purl.org/pan-science/PaNET/PaNET01173",
+                  "http://purl.org/pan-science/PaNET/PaNET01325",
+                  "http://purl.org/pan-science/PaNET/PaNET01258",
+                  "http://purl.org/pan-science/PaNET/PaNET01162",
+                  "http://purl.org/pan-science/PaNET/PaNET01286",
+                  "http://purl.org/pan-science/PaNET/PaNET01287",
+                  "http://purl.org/pan-science/PaNET/PaNET01297",
+                  "http://purl.org/pan-science/PaNET/PaNET01165",
+                  "http://purl.org/pan-science/PaNET/PaNET01289",
+                  "http://purl.org/pan-science/PaNET/PaNET01285",
+                  "http://purl.org/pan-science/PaNET/PaNET01241",
+                  "http://purl.org/pan-science/PaNET/PaNET01295",
+                  "http://purl.org/pan-science/PaNET/PaNET01101",
+                  "http://purl.org/pan-science/PaNET/PaNET01140",
+                  "http://purl.org/pan-science/PaNET/PaNET01322",
+                  "http://purl.org/pan-science/PaNET/PaNET01160",
+                  "http://purl.org/pan-science/PaNET/PaNET01294",
+                  "http://purl.org/pan-science/PaNET/PaNET01198",
+                  "http://purl.org/pan-science/PaNET/PaNET01321",
+                  "http://purl.org/pan-science/PaNET/PaNET01193"                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Dataset returned
+ | Query 7 datasets  |
+ | ---------------------------- |
+ | PID.SAMPLE.PREFIX/dls_ds1 | 
+ | PID.SAMPLE.PREFIX/dls_ds2 | 
+ | PID.SAMPLE.PREFIX/hzdr_ds1 | 
+ | PID.SAMPLE.PREFIX/maxiv_ds2 | 
+ | PID.SAMPLE.PREFIX/ukri_ds5 | 
+ | PID.SAMPLE.PREFIX/ukri_ds6 |
+
+
+\
+Query details: 
+- techniques highlighted with **bold** are the ones matching the first operand of the logical and in the query, 
+- techniques highlighted with *italic* are the ones matching the second operand of the logical and in the query,
+- techniques highlighted with ***bold and italic*** are the ones matching both the first and second operand of the logical and in the query,
+- only datasets tagged with techniques that match the 2 and operands are selected 
+
+ 
+ | Selected | Dataset id | Technique Name | Technique PID |
+ | :-: | - | - | - |
+ |   | PID.SAMPLE.PREFIX/desy_ds1 | *resonant inelastic x-ray scattering* | *http://purl.org/pan-science/PaNET/PaNET01183* | 
+ |   | PID.SAMPLE.PREFIX/desy_ds2 | *resonant inelastic x-ray scattering*	| *http://purl.org/pan-science/PaNET/PaNET01183* |
+ |   | PID.SAMPLE.PREFIX/desy_ds3 | *resonant inelastic x-ray scattering*	| *http://purl.org/pan-science/PaNET/PaNET01183* |
+ | Y | PID.SAMPLE.PREFIX/dls_ds1 | ***anomalous solution x-ray scattering***	| ***http://purl.org/pan-science/PaNET/PaNET01275*** |
+ | Y | PID.SAMPLE.PREFIX/dls_ds2 | ***grazing incidence small angle x-ray scattering***	| ***http://purl.org/pan-science/PaNET/PaNET01162*** |
+ | Y | PID.SAMPLE.PREFIX/hzdr_ds1 | **inelastic x-ray small angle scattering**	| **http://purl.org/pan-science/PaNET/PaNET01281** |
+ |   | PID.SAMPLE.PREFIX/maxiv_ds1 | *resonant inelastic x-ray scattering* | *http://purl.org/pan-science/PaNET/PaNET01183* |
+ | Y | PID.SAMPLE.PREFIX/maxiv_ds2 | ***soft x-ray small angle scattering***	| ***http://purl.org/pan-science/PaNET/PaNET01282*** |
+ |   | PID.SAMPLE.PREFIX/psi_ds1 | *magnetic x-ray tomography*	| *http://purl.org/pan-science/PaNET/PaNET01313* |
+ |   | PID.SAMPLE.PREFIX/psi_ds2 | *magnetic x-ray tomography*  | *http://purl.org/pan-science/PaNET/PaNET01313* |
+ |   | PID.SAMPLE.PREFIX/psi_ds3 | *magnetic x-ray tomography*  | *http://purl.org/pan-science/PaNET/PaNET01313* |
+ |   | PID.SAMPLE.PREFIX/soleil_ds1 | *x-ray emission spectroscopy*  | *http://purl.org/pan-science/PaNET/PaNET01200* |
+ |   | PID.SAMPLE.PREFIX/soleil_ds2 | *x-ray emission spectroscopy*  | *http://purl.org/pan-science/PaNET/PaNET01200* |
+ |   | PID.SAMPLE.PREFIX/ukri_ds1 | *x-ray emission spectroscopy* ,<br /> *magnetic x-ray tomography* | *http://purl.org/pan-science/PaNET/PaNET01200* ,<br /> *http://purl.org/pan-science/PaNET/PaNET01313* |
+ |   | PID.SAMPLE.PREFIX/ukri_ds2 | *x-ray emission spectroscopy* ,<br /> *magnetic x-ray tomography* | *http://purl.org/pan-science/PaNET/PaNET01200* ,<br /> *http://purl.org/pan-science/PaNET/PaNET01313* |
+ |   | PID.SAMPLE.PREFIX/ukri_ds3 | *x-ray emission spectroscopy* ,<br /> *magnetic x-ray tomography* | *http://purl.org/pan-science/PaNET/PaNET01200* ,<br /> *http://purl.org/pan-science/PaNET/PaNET01313* |
+ |   | PID.SAMPLE.PREFIX/ukri_ds4 | *x-ray emission spectroscopy* ,<br /> *magnetic x-ray tomography* | *http://purl.org/pan-science/PaNET/PaNET01200* ,<br /> *http://purl.org/pan-science/PaNET/PaNET01313* |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds5 | *x-ray emission spectroscopy* ,<br /> **grazing incidence small angle scattering** | *http://purl.org/pan-science/PaNET/PaNET01200* ,<br /> ***http://purl.org/pan-science/PaNET/PaNET01162*** |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds6 | *x-ray emission spectroscopy* ,<br /> **anomalous solution x-ray scattering** | *http://purl.org/pan-science/PaNET/PaNET01200* ,<br /> ***http://purl.org/pan-science/PaNET/PaNET01275*** |
+
+
+#### Status
+*verified* and *validated*
+
+
+
+### Query 8
+
+#### Use case:
+A user is searching for datasets tagged with both techniques *small angle scattering* or *x-ray probe* or any of their descendants 
+
+#### User query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "or": [
+            {
+              "name": "small angle scattering"
+            },
+            {
+              "name": "x-ray probe"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+Compact format:  
+```json
+{"include":[{"relation":"techniques","scope":{"where":{"or":[{"name":"small angle scattering"},{"name": "x-ray probe"}]}}}]}
+```
+
+Request URL:  
+`http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22or%22%3A%5B%7B%22name%22%3A%22small%20angle%20scattering%22%7D%2C%7B%22name%22%3A%20%22x-ray%20probe%22%7D%5D%7D%7D%7D%5D%7D`
+
+Curl commnad
+```bash
+curl -X GET --header 'Accept: application/json' 'http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22or%22%3A%5B%7B%22name%22%3A%22small%20angle%20scattering%22%7D%2C%7B%22name%22%3A%20%22x-ray%20probe%22%7D%5D%7D%7D%7D%5D%7D'
+```
+
+Equivalent user query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "or": [
+            {
+              "name": {
+                "eq" : "small angle scattering"
+              }
+            },
+            {
+              "name": {
+                "eq" : "x-ray probe"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+
+
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "or" : [
+            {
+              "pid" : "http://purl.org/pan-science/PaNET/PaNET01124"
+            },
+            {
+              "pid" : "http://purl.org/pan-science/PaNET/PaNET01012"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "or" : [
+            {
+              "pid" : {
+                "eq" : "http://purl.org/pan-science/PaNET/PaNET01124"
+              }
+            },
+            {
+              "pid" : {
+                "eq" : "http://purl.org/pan-science/PaNET/PaNET01012"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+Interpreted query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "or":[
+            {
+              "pid" : {
+                "inq" : [
+                  "http://purl.org/pan-science/PaNET/PaNET01124",
+                  "http://purl.org/pan-science/PaNET/PaNET01127",
+                  "http://purl.org/pan-science/PaNET/PaNET01189",
+                  "http://purl.org/pan-science/PaNET/PaNET01277",
+                  "http://purl.org/pan-science/PaNET/PaNET01099",
+                  "http://purl.org/pan-science/PaNET/PaNET01276",
+                  "http://purl.org/pan-science/PaNET/PaNET01133",
+                  "http://purl.org/pan-science/PaNET/PaNET01278",
+                  "http://purl.org/pan-science/PaNET/PaNET01274",
+                  "http://purl.org/pan-science/PaNET/PaNET01275",
+                  "http://purl.org/pan-science/PaNET/PaNET01188",
+                  "http://purl.org/pan-science/PaNET/PaNET01282",
+                  "http://purl.org/pan-science/PaNET/PaNET01281",
+                  "http://purl.org/pan-science/PaNET/PaNET01273",
+                  "http://purl.org/pan-science/PaNET/PaNET01279",
+                  "http://purl.org/pan-science/PaNET/PaNET01280",
+                  "http://purl.org/pan-science/PaNET/PaNET01107",
+                  "http://purl.org/pan-science/PaNET/PaNET01162",
+                  "http://purl.org/pan-science/PaNET/PaNET01286",
+                  "http://purl.org/pan-science/PaNET/PaNET01287",
+                  "http://purl.org/pan-science/PaNET/PaNET01241",
+                  "http://purl.org/pan-science/PaNET/PaNET01240"
+                ]
+              }
+            },
+            {
+              "pid" : {
+                "inq" : [
+                  "http://purl.org/pan-science/PaNET/PaNET01012",
+                  "http://purl.org/pan-science/PaNET/PaNET01161",
+                  "http://purl.org/pan-science/PaNET/PaNET01290",
+                  "http://purl.org/pan-science/PaNET/PaNET01208",
+                  "http://purl.org/pan-science/PaNET/PaNET01219",
+                  "http://purl.org/pan-science/PaNET/PaNET01102",
+                  "http://purl.org/pan-science/PaNET/PaNET01168",
+                  "http://purl.org/pan-science/PaNET/PaNET01309",
+                  "http://purl.org/pan-science/PaNET/PaNET01184",
+                  "http://purl.org/pan-science/PaNET/PaNET01271",
+                  "http://purl.org/pan-science/PaNET/PaNET01306",
+                  "http://purl.org/pan-science/PaNET/PaNET01014",
+                  "http://purl.org/pan-science/PaNET/PaNET01305",
+                  "http://purl.org/pan-science/PaNET/PaNET01216",
+                  "http://purl.org/pan-science/PaNET/PaNET01227",
+                  "http://purl.org/pan-science/PaNET/PaNET01204",
+                  "http://purl.org/pan-science/PaNET/PaNET01218",
+                  "http://purl.org/pan-science/PaNET/PaNET01156",
+                  "http://purl.org/pan-science/PaNET/PaNET01229",
+                  "http://purl.org/pan-science/PaNET/PaNET01272",
+                  "http://purl.org/pan-science/PaNET/PaNET01307",
+                  "http://purl.org/pan-science/PaNET/PaNET01266",
+                  "http://purl.org/pan-science/PaNET/PaNET01303",
+                  "http://purl.org/pan-science/PaNET/PaNET01095",
+                  "http://purl.org/pan-science/PaNET/PaNET01200",
+                  "http://purl.org/pan-science/PaNET/PaNET01207",
+                  "http://purl.org/pan-science/PaNET/PaNET01313",
+                  "http://purl.org/pan-science/PaNET/PaNET01186",
+                  "http://purl.org/pan-science/PaNET/PaNET01187",
+                  "http://purl.org/pan-science/PaNET/PaNET01015",
+                  "http://purl.org/pan-science/PaNET/PaNET01302",
+                  "http://purl.org/pan-science/PaNET/PaNET01180",
+                  "http://purl.org/pan-science/PaNET/PaNET01314",
+                  "http://purl.org/pan-science/PaNET/PaNET01224",
+                  "http://purl.org/pan-science/PaNET/PaNET01191",
+                  "http://purl.org/pan-science/PaNET/PaNET01316",
+                  "http://purl.org/pan-science/PaNET/PaNET01315",
+                  "http://purl.org/pan-science/PaNET/PaNET01169",
+                  "http://purl.org/pan-science/PaNET/PaNET01312",
+                  "http://purl.org/pan-science/PaNET/PaNET01301",
+                  "http://purl.org/pan-science/PaNET/PaNET01311",
+                  "http://purl.org/pan-science/PaNET/PaNET01262",
+                  "http://purl.org/pan-science/PaNET/PaNET01261",
+                  "http://purl.org/pan-science/PaNET/PaNET01284",
+                  "http://purl.org/pan-science/PaNET/PaNET01167",
+                  "http://purl.org/pan-science/PaNET/PaNET01182",
+                  "http://purl.org/pan-science/PaNET/PaNET01183",
+                  "http://purl.org/pan-science/PaNET/PaNET01172",
+                  "http://purl.org/pan-science/PaNET/PaNET01310",
+                  "http://purl.org/pan-science/PaNET/PaNET01137",
+                  "http://purl.org/pan-science/PaNET/PaNET01221",
+                  "http://purl.org/pan-science/PaNET/PaNET01274",
+                  "http://purl.org/pan-science/PaNET/PaNET01275",
+                  "http://purl.org/pan-science/PaNET/PaNET01283",
+                  "http://purl.org/pan-science/PaNET/PaNET01188",
+                  "http://purl.org/pan-science/PaNET/PaNET01282",
+                  "http://purl.org/pan-science/PaNET/PaNET01260",
+                  "http://purl.org/pan-science/PaNET/PaNET01281",
+                  "http://purl.org/pan-science/PaNET/PaNET01280",
+                  "http://purl.org/pan-science/PaNET/PaNET01149",
+                  "http://purl.org/pan-science/PaNET/PaNET01013",
+                  "http://purl.org/pan-science/PaNET/PaNET01103",
+                  "http://purl.org/pan-science/PaNET/PaNET01300",
+                  "http://purl.org/pan-science/PaNET/PaNET01327",
+                  "http://purl.org/pan-science/PaNET/PaNET01205",
+                  "http://purl.org/pan-science/PaNET/PaNET01238",
+                  "http://purl.org/pan-science/PaNET/PaNET01196",
+                  "http://purl.org/pan-science/PaNET/PaNET01197",
+                  "http://purl.org/pan-science/PaNET/PaNET01199",
+                  "http://purl.org/pan-science/PaNET/PaNET01259",
+                  "http://purl.org/pan-science/PaNET/PaNET01173",
+                  "http://purl.org/pan-science/PaNET/PaNET01325",
+                  "http://purl.org/pan-science/PaNET/PaNET01258",
+                  "http://purl.org/pan-science/PaNET/PaNET01162",
+                  "http://purl.org/pan-science/PaNET/PaNET01286",
+                  "http://purl.org/pan-science/PaNET/PaNET01287",
+                  "http://purl.org/pan-science/PaNET/PaNET01297",
+                  "http://purl.org/pan-science/PaNET/PaNET01165",
+                  "http://purl.org/pan-science/PaNET/PaNET01289",
+                  "http://purl.org/pan-science/PaNET/PaNET01285",
+                  "http://purl.org/pan-science/PaNET/PaNET01241",
+                  "http://purl.org/pan-science/PaNET/PaNET01295",
+                  "http://purl.org/pan-science/PaNET/PaNET01101",
+                  "http://purl.org/pan-science/PaNET/PaNET01140",
+                  "http://purl.org/pan-science/PaNET/PaNET01322",
+                  "http://purl.org/pan-science/PaNET/PaNET01160",
+                  "http://purl.org/pan-science/PaNET/PaNET01294",
+                  "http://purl.org/pan-science/PaNET/PaNET01198",
+                  "http://purl.org/pan-science/PaNET/PaNET01321",
+                  "http://purl.org/pan-science/PaNET/PaNET01193"                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Dataset returned
+*PID.SAMPLE.PREFIX/desy_ds1 , PID.SAMPLE.PREFIX/desy_ds2 , PID.SAMPLE.PREFIX/desy_ds3 , PID.SAMPLE.PREFIX/dls_ds1 , PID.SAMPLE.PREFIX/dls_ds2 , PID.SAMPLE.PREFIX/hzdr_ds1 , PID.SAMPLE.PREFIX/maxiv_ds1 , PID.SAMPLE.PREFIX/maxiv_ds2 , PID.SAMPLE.PREFIX/psi_ds1 , PID.SAMPLE.PREFIX/psi_ds2 , PID.SAMPLE.PREFIX/psi_ds3 , PID.SAMPLE.PREFIX/soleil_ds1 , PID.SAMPLE.PREFIX/soleil_ds2 , PID.SAMPLE.PREFIX/ukri_ds1 , PID.SAMPLE.PREFIX/ukri_ds2 , PID.SAMPLE.PREFIX/ukri_ds3 , PID.SAMPLE.PREFIX/ukri_ds4 , PID.SAMPLE.PREFIX/ukri_ds5 , PID.SAMPLE.PREFIX/ukri_ds6*
+
+\
+Query details: 
+- techniques highlighted with **bold** are the ones matching the first operand of the logical and in the query, 
+- techniques highlighted with *italic* are the ones matching the second operand of the logical and in the query,
+- techniques highlighted with ***bold and italic*** are the ones matching both the first and second operand of the logical and in the query,
+ 
+ | Selected | Dataset id | Technique Name | Technique PID |
+ | :-: | - | - | - |
+ | Y | PID.SAMPLE.PREFIX/desy_ds1 | *resonant inelastic x-ray scattering* | *http://purl.org/pan-science/PaNET/PaNET01183* | 
+ | Y | PID.SAMPLE.PREFIX/desy_ds2 | *resonant inelastic x-ray scattering*	| *http://purl.org/pan-science/PaNET/PaNET01183* |
+ | Y | PID.SAMPLE.PREFIX/desy_ds3 | *resonant inelastic x-ray scattering*	| *http://purl.org/pan-science/PaNET/PaNET01183* |
+ | Y | PID.SAMPLE.PREFIX/dls_ds1 | ***anomalous solution x-ray scattering***	| ***http://purl.org/pan-science/PaNET/PaNET01275*** |
+ | Y | PID.SAMPLE.PREFIX/dls_ds2 | ***grazing incidence small angle x-ray scattering***	| ***http://purl.org/pan-science/PaNET/PaNET01162*** |
+ | Y | PID.SAMPLE.PREFIX/hzdr_ds1 | ***inelastic x-ray small angle scattering***	| ***http://purl.org/pan-science/PaNET/PaNET01281*** |
+ | Y | PID.SAMPLE.PREFIX/maxiv_ds1 | *resonant inelastic x-ray scattering* | *http://purl.org/pan-science/PaNET/PaNET01183* |
+ | Y | PID.SAMPLE.PREFIX/maxiv_ds2 | ***soft x-ray small angle scattering***	| ***http://purl.org/pan-science/PaNET/PaNET01282*** |
+ | Y | PID.SAMPLE.PREFIX/psi_ds1 | *magnetic x-ray tomography*	| *http://purl.org/pan-science/PaNET/PaNET01313* |
+ | Y | PID.SAMPLE.PREFIX/psi_ds2 | *magnetic x-ray tomography*  | *http://purl.org/pan-science/PaNET/PaNET01313* |
+ | Y | PID.SAMPLE.PREFIX/psi_ds3 | *magnetic x-ray tomography*  | *http://purl.org/pan-science/PaNET/PaNET01313* |
+ | Y | PID.SAMPLE.PREFIX/soleil_ds1 | *x-ray emission spectroscopy*  | *http://purl.org/pan-science/PaNET/PaNET01200* |
+ | Y | PID.SAMPLE.PREFIX/soleil_ds2 | *x-ray emission spectroscopy*  | *http://purl.org/pan-science/PaNET/PaNET01200* |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds1 | *x-ray emission spectroscopy* ,<br /> *magnetic x-ray tomography* | *http://purl.org/pan-science/PaNET/PaNET01200* ,<br /> *http://purl.org/pan-science/PaNET/PaNET01313* |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds2 | *x-ray emission spectroscopy* ,<br /> *magnetic x-ray tomography* | *http://purl.org/pan-science/PaNET/PaNET01200* ,<br /> *http://purl.org/pan-science/PaNET/PaNET01313* |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds3 | *x-ray emission spectroscopy* ,<br /> *magnetic x-ray tomography* | *http://purl.org/pan-science/PaNET/PaNET01200* ,<br /> *http://purl.org/pan-science/PaNET/PaNET01313* |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds4 | *x-ray emission spectroscopy* ,<br /> *magnetic x-ray tomography* | *http://purl.org/pan-science/PaNET/PaNET01200* ,<br /> *http://purl.org/pan-science/PaNET/PaNET01313* |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds5 | *x-ray emission spectroscopy* ,<br /> ***grazing incidence small angle scattering*** | *http://purl.org/pan-science/PaNET/PaNET01200* ,<br /> ***http://purl.org/pan-science/PaNET/PaNET01162*** |
+ | Y | PID.SAMPLE.PREFIX/ukri_ds6 | *x-ray emission spectroscopy* ,<br /> ***anomalous solution x-ray scattering*** | *http://purl.org/pan-science/PaNET/PaNET01200* ,<br /> ***http://purl.org/pan-science/PaNET/PaNET01275*** |
+
+
+#### Status
+*verified* and *validated*
+
+
+
+### Query 9
+
+#### Use case:
+A user is looking for datasets tagged with technique *small angle scattering* or any of its descendants but not with *x-ray probe* or any of its descendants 
+
+#### User query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and": [
+            {
+              "name": "small angle scattering"
+            },
+            {
+              "name": {
+                "neq": "x-ray probe"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+Compact format:  
+```json
+{"include":[{"relation":"techniques","scope":{"where":{"and":[{"name":"small angle scattering"},{"name": {"neq" : "x-ray probe"}}]}}}]}
+```
+
+Request URL:  
+`http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22and%22%3A%5B%7B%22name%22%3A%22small%20angle%20scattering%22%7D%2C%7B%22name%22%3A%20%7B%22neq%22%20%3A%20%22x-ray%20probe%22%7D%7D%5D%7D%7D%7D%5D%7D`
+
+Curl commnad
+```bash
+curl -X GET --header 'Accept: application/json' 'http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22and%22%3A%5B%7B%22name%22%3A%22small%20angle%20scattering%22%7D%2C%7B%22name%22%3A%20%7B%22neq%22%20%3A%20%22x-ray%20probe%22%7D%7D%5D%7D%7D%7D%5D%7D'
+```
+
+Equivalent user query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and": [
+            {
+              "name": {
+                "eq" : "small angle scattering"
+              }
+            },
+            {
+              "name": {
+                "neq" : "x-ray probe"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+
+
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and" : [
+            {
+              "pid" : "http://purl.org/pan-science/PaNET/PaNET01124"
+            },
+            {
+              "pid" : {
+                "new" : "http://purl.org/pan-science/PaNET/PaNET01012"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and" : [
+            {
+              "pid" : {
+                "eq" : "http://purl.org/pan-science/PaNET/PaNET01124"
+              }
+            },
+            {
+              "pid" : {
+                "neq" : "http://purl.org/pan-science/PaNET/PaNET01012"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+Interpreted query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and":[
+            {
+              "pid" : {
+                "inq" : [
+                  "http://purl.org/pan-science/PaNET/PaNET01124",
+                  "http://purl.org/pan-science/PaNET/PaNET01127",
+                  "http://purl.org/pan-science/PaNET/PaNET01189",
+                  "http://purl.org/pan-science/PaNET/PaNET01277",
+                  "http://purl.org/pan-science/PaNET/PaNET01099",
+                  "http://purl.org/pan-science/PaNET/PaNET01276",
+                  "http://purl.org/pan-science/PaNET/PaNET01133",
+                  "http://purl.org/pan-science/PaNET/PaNET01278",
+                  "http://purl.org/pan-science/PaNET/PaNET01274",
+                  "http://purl.org/pan-science/PaNET/PaNET01275",
+                  "http://purl.org/pan-science/PaNET/PaNET01188",
+                  "http://purl.org/pan-science/PaNET/PaNET01282",
+                  "http://purl.org/pan-science/PaNET/PaNET01281",
+                  "http://purl.org/pan-science/PaNET/PaNET01273",
+                  "http://purl.org/pan-science/PaNET/PaNET01279",
+                  "http://purl.org/pan-science/PaNET/PaNET01280",
+                  "http://purl.org/pan-science/PaNET/PaNET01107",
+                  "http://purl.org/pan-science/PaNET/PaNET01162",
+                  "http://purl.org/pan-science/PaNET/PaNET01286",
+                  "http://purl.org/pan-science/PaNET/PaNET01287",
+                  "http://purl.org/pan-science/PaNET/PaNET01241",
+                  "http://purl.org/pan-science/PaNET/PaNET01240"
+                ]
+              }
+            },
+            {
+              "pid" : {
+                "nin" : [
+                  "http://purl.org/pan-science/PaNET/PaNET01012",
+                  "http://purl.org/pan-science/PaNET/PaNET01161",
+                  "http://purl.org/pan-science/PaNET/PaNET01290",
+                  "http://purl.org/pan-science/PaNET/PaNET01208",
+                  "http://purl.org/pan-science/PaNET/PaNET01219",
+                  "http://purl.org/pan-science/PaNET/PaNET01102",
+                  "http://purl.org/pan-science/PaNET/PaNET01168",
+                  "http://purl.org/pan-science/PaNET/PaNET01309",
+                  "http://purl.org/pan-science/PaNET/PaNET01184",
+                  "http://purl.org/pan-science/PaNET/PaNET01271",
+                  "http://purl.org/pan-science/PaNET/PaNET01306",
+                  "http://purl.org/pan-science/PaNET/PaNET01014",
+                  "http://purl.org/pan-science/PaNET/PaNET01305",
+                  "http://purl.org/pan-science/PaNET/PaNET01216",
+                  "http://purl.org/pan-science/PaNET/PaNET01227",
+                  "http://purl.org/pan-science/PaNET/PaNET01204",
+                  "http://purl.org/pan-science/PaNET/PaNET01218",
+                  "http://purl.org/pan-science/PaNET/PaNET01156",
+                  "http://purl.org/pan-science/PaNET/PaNET01229",
+                  "http://purl.org/pan-science/PaNET/PaNET01272",
+                  "http://purl.org/pan-science/PaNET/PaNET01307",
+                  "http://purl.org/pan-science/PaNET/PaNET01266",
+                  "http://purl.org/pan-science/PaNET/PaNET01303",
+                  "http://purl.org/pan-science/PaNET/PaNET01095",
+                  "http://purl.org/pan-science/PaNET/PaNET01200",
+                  "http://purl.org/pan-science/PaNET/PaNET01207",
+                  "http://purl.org/pan-science/PaNET/PaNET01313",
+                  "http://purl.org/pan-science/PaNET/PaNET01186",
+                  "http://purl.org/pan-science/PaNET/PaNET01187",
+                  "http://purl.org/pan-science/PaNET/PaNET01015",
+                  "http://purl.org/pan-science/PaNET/PaNET01302",
+                  "http://purl.org/pan-science/PaNET/PaNET01180",
+                  "http://purl.org/pan-science/PaNET/PaNET01314",
+                  "http://purl.org/pan-science/PaNET/PaNET01224",
+                  "http://purl.org/pan-science/PaNET/PaNET01191",
+                  "http://purl.org/pan-science/PaNET/PaNET01316",
+                  "http://purl.org/pan-science/PaNET/PaNET01315",
+                  "http://purl.org/pan-science/PaNET/PaNET01169",
+                  "http://purl.org/pan-science/PaNET/PaNET01312",
+                  "http://purl.org/pan-science/PaNET/PaNET01301",
+                  "http://purl.org/pan-science/PaNET/PaNET01311",
+                  "http://purl.org/pan-science/PaNET/PaNET01262",
+                  "http://purl.org/pan-science/PaNET/PaNET01261",
+                  "http://purl.org/pan-science/PaNET/PaNET01284",
+                  "http://purl.org/pan-science/PaNET/PaNET01167",
+                  "http://purl.org/pan-science/PaNET/PaNET01182",
+                  "http://purl.org/pan-science/PaNET/PaNET01183",
+                  "http://purl.org/pan-science/PaNET/PaNET01172",
+                  "http://purl.org/pan-science/PaNET/PaNET01310",
+                  "http://purl.org/pan-science/PaNET/PaNET01137",
+                  "http://purl.org/pan-science/PaNET/PaNET01221",
+                  "http://purl.org/pan-science/PaNET/PaNET01274",
+                  "http://purl.org/pan-science/PaNET/PaNET01275",
+                  "http://purl.org/pan-science/PaNET/PaNET01283",
+                  "http://purl.org/pan-science/PaNET/PaNET01188",
+                  "http://purl.org/pan-science/PaNET/PaNET01282",
+                  "http://purl.org/pan-science/PaNET/PaNET01260",
+                  "http://purl.org/pan-science/PaNET/PaNET01281",
+                  "http://purl.org/pan-science/PaNET/PaNET01280",
+                  "http://purl.org/pan-science/PaNET/PaNET01149",
+                  "http://purl.org/pan-science/PaNET/PaNET01013",
+                  "http://purl.org/pan-science/PaNET/PaNET01103",
+                  "http://purl.org/pan-science/PaNET/PaNET01300",
+                  "http://purl.org/pan-science/PaNET/PaNET01327",
+                  "http://purl.org/pan-science/PaNET/PaNET01205",
+                  "http://purl.org/pan-science/PaNET/PaNET01238",
+                  "http://purl.org/pan-science/PaNET/PaNET01196",
+                  "http://purl.org/pan-science/PaNET/PaNET01197",
+                  "http://purl.org/pan-science/PaNET/PaNET01199",
+                  "http://purl.org/pan-science/PaNET/PaNET01259",
+                  "http://purl.org/pan-science/PaNET/PaNET01173",
+                  "http://purl.org/pan-science/PaNET/PaNET01325",
+                  "http://purl.org/pan-science/PaNET/PaNET01258",
+                  "http://purl.org/pan-science/PaNET/PaNET01162",
+                  "http://purl.org/pan-science/PaNET/PaNET01286",
+                  "http://purl.org/pan-science/PaNET/PaNET01287",
+                  "http://purl.org/pan-science/PaNET/PaNET01297",
+                  "http://purl.org/pan-science/PaNET/PaNET01165",
+                  "http://purl.org/pan-science/PaNET/PaNET01289",
+                  "http://purl.org/pan-science/PaNET/PaNET01285",
+                  "http://purl.org/pan-science/PaNET/PaNET01241",
+                  "http://purl.org/pan-science/PaNET/PaNET01295",
+                  "http://purl.org/pan-science/PaNET/PaNET01101",
+                  "http://purl.org/pan-science/PaNET/PaNET01140",
+                  "http://purl.org/pan-science/PaNET/PaNET01322",
+                  "http://purl.org/pan-science/PaNET/PaNET01160",
+                  "http://purl.org/pan-science/PaNET/PaNET01294",
+                  "http://purl.org/pan-science/PaNET/PaNET01198",
+                  "http://purl.org/pan-science/PaNET/PaNET01321",
+                  "http://purl.org/pan-science/PaNET/PaNET01193"                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Dataset returned
+No dataset is returnec
+
+\
+Query details: 
+- techniques highlighted with **bold** are the ones matching the first operand of the logical and in the query, 
+- techniques highlighted with ~~strikethrough~~ are the ones matching the second operand of the logical and in the query. They need not to be present in order for the dataset to be selected
+- techniques highlighted with ~~**bold and strikethrought**~~ are the ones matching both the first and second operand of the logical and in the query,
+ 
+ | Selected | Dataset id | Technique Name | Technique PID |
+ | :-: | - | - | - |
+ |   | PID.SAMPLE.PREFIX/desy_ds1 | ~~resonant inelastic x-ray scattering~~ | ~~http://purl.org/pan-science/PaNET/PaNET01183~~ | 
+ |   | PID.SAMPLE.PREFIX/desy_ds2 | ~~resonant inelastic x-ray scattering~~	| ~~http://purl.org/pan-science/PaNET/PaNET01183~~ |
+ |   | PID.SAMPLE.PREFIX/desy_ds3 | ~~resonant inelastic x-ray scattering~~	| ~~http://purl.org/pan-science/PaNET/PaNET01183~~ |
+ |   | PID.SAMPLE.PREFIX/dls_ds1 | ~~**anomalous solution x-ray scattering**~~	| ~~**http://purl.org/pan-science/PaNET/PaNET01275**~~ |
+ |   | PID.SAMPLE.PREFIX/dls_ds2 | ~~**grazing incidence small angle x-ray scattering**~~	| ~~**http://purl.org/pan-science/PaNET/PaNET01162**~~ |
+ |   | PID.SAMPLE.PREFIX/hzdr_ds1 | ~~**inelastic x-ray small angle scattering**~~	| ~~**http://purl.org/pan-science/PaNET/PaNET01281**~~ |
+ |   | PID.SAMPLE.PREFIX/maxiv_ds1 | ~~resonant inelastic x-ray scattering~~ | ~~http://purl.org/pan-science/PaNET/PaNET01183~~ |
+ |   | PID.SAMPLE.PREFIX/maxiv_ds2 | ~~**soft x-ray small angle scattering**~~	| ~~**http://purl.org/pan-science/PaNET/PaNET01282**~~ |
+ |   | PID.SAMPLE.PREFIX/psi_ds1 | ~~magnetic x-ray tomography~~	| ~~http://purl.org/pan-science/PaNET/PaNET01313~~ |
+ |   | PID.SAMPLE.PREFIX/psi_ds2 | ~~magnetic x-ray tomography~~  | ~~http://purl.org/pan-science/PaNET/PaNET01313~~ |
+ |   | PID.SAMPLE.PREFIX/psi_ds3 | ~~magnetic x-ray tomography~~  | ~~http://purl.org/pan-science/PaNET/PaNET01313~~ |
+ |   | PID.SAMPLE.PREFIX/soleil_ds1 | ~~x-ray emission spectroscopy~~  | ~~http://purl.org/pan-science/PaNET/PaNET01200~~ |
+ |   | PID.SAMPLE.PREFIX/soleil_ds2 | ~~x-ray emission spectroscopy~~  | ~~http://purl.org/pan-science/PaNET/PaNET01200~~ |
+ |   | PID.SAMPLE.PREFIX/ukri_ds1 | ~~x-ray emission spectroscopy~~ ,<br /> ~~magnetic x-ray tomography~~ | ~~http://purl.org/pan-science/PaNET/PaNET01200~~ ,<br /> ~~http://purl.org/pan-science/PaNET/PaNET01313~~ |
+ |   | PID.SAMPLE.PREFIX/ukri_ds2 | ~~x-ray emission spectroscopy~~ ,<br /> ~~magnetic x-ray tomography~~ | ~~http://purl.org/pan-science/PaNET/PaNET01200~~ ,<br /> ~~http://purl.org/pan-science/PaNET/PaNET01313~~ |
+ |   | PID.SAMPLE.PREFIX/ukri_ds3 | ~~x-ray emission spectroscopy~~ ,<br /> ~~magnetic x-ray tomography~~ | ~~http://purl.org/pan-science/PaNET/PaNET01200~~ ,<br /> ~~http://purl.org/pan-science/PaNET/PaNET01313~~ |
+ |   | PID.SAMPLE.PREFIX/ukri_ds4 | ~~x-ray emission spectroscopy~~ ,<br /> ~~magnetic x-ray tomography~~ | ~~http://purl.org/pan-science/PaNET/PaNET01200~~ ,<br /> ~~http://purl.org/pan-science/PaNET/PaNET01313~~ |
+ |   | PID.SAMPLE.PREFIX/ukri_ds5 | ~~x-ray emission spectroscopy~~ ,<br /> ~~**grazing incidence small angle scattering**~~ | ~~http://purl.org/pan-science/PaNET/PaNET01200~~ ,<br /> ~~**http://purl.org/pan-science/PaNET/PaNET01162**~~ |
+ |   | PID.SAMPLE.PREFIX/ukri_ds6 | ~~x-ray emission spectroscopy~~ ,<br /> ~~**anomalous solution x-ray scattering**~~ | ~~http://purl.org/pan-science/PaNET/PaNET01200~~ ,<br /> ~~**http://purl.org/pan-science/PaNET/PaNET01275**~~ |
+
+
+#### Status
+*verified* and *validated*
+
+
+### Query 9
+
+#### Use case:
+A user is looking for datasets tagged with technique *small angle scattering* or any of its descendants but not with *magnetism technique* or any of its descendants 
+
+#### User query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and": [
+            {
+              "name": "small angle scattering"
+            },
+            {
+              "name": {
+                "neq": "magnetism technique"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+Compact format:  
+```json
+{"include":[{"relation":"techniques","scope":{"where":{"and":[{"name":"small angle scattering"},{"name": {"neq" : "magnetism technique"}}]}}}]}
+```
+
+Request URL:  
+`http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22and%22%3A%5B%7B%22name%22%3A%22small%20angle%20scattering%22%7D%2C%7B%22name%22%3A%20%7B%22neq%22%20%3A%20%22magnetism%20technique%22%7D%7D%5D%7D%7D%7D%5D%7D`
+
+Curl commnad
+```bash
+curl -X GET --header 'Accept: application/json' 'http://localhost/panosc-api/Datasets?filter=%7B%22include%22%3A%5B%7B%22relation%22%3A%22techniques%22%2C%22scope%22%3A%7B%22where%22%3A%7B%22and%22%3A%5B%7B%22name%22%3A%22small%20angle%20scattering%22%7D%2C%7B%22name%22%3A%20%7B%22neq%22%20%3A%20%22magnetism%20technique%22%7D%7D%5D%7D%7D%7D%5D%7D'
+```
+
+Equivalent user query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and": [
+            {
+              "name": {
+                "eq" : "small angle scattering"
+              }
+            },
+            {
+              "name": {
+                "neq" : "magnetism technique"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+
+
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and" : [
+            {
+              "pid" : "http://purl.org/pan-science/PaNET/PaNET01124"
+            },
+            {
+              "pid" : {
+                "new" : "http://purl.org/pan-science/PaNET/PaNET00207"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and" : [
+            {
+              "pid" : {
+                "eq" : "http://purl.org/pan-science/PaNET/PaNET01124"
+              }
+            },
+            {
+              "pid" : {
+                "neq" : "http://purl.org/pan-science/PaNET/PaNET00207"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+Interpreted query:
+```json
+{
+  "include": [
+    {
+      "relation": "techniques",
+      "scope": {
+        "where": {
+          "and":[
+            {
+              "pid" : {
+                "inq" : [
+                  "http://purl.org/pan-science/PaNET/PaNET01124",
+                  "http://purl.org/pan-science/PaNET/PaNET01127",
+                  "http://purl.org/pan-science/PaNET/PaNET01189",
+                  "http://purl.org/pan-science/PaNET/PaNET01277",
+                  "http://purl.org/pan-science/PaNET/PaNET01099",
+                  "http://purl.org/pan-science/PaNET/PaNET01276",
+                  "http://purl.org/pan-science/PaNET/PaNET01133",
+                  "http://purl.org/pan-science/PaNET/PaNET01278",
+                  "http://purl.org/pan-science/PaNET/PaNET01274",
+                  "http://purl.org/pan-science/PaNET/PaNET01275",
+                  "http://purl.org/pan-science/PaNET/PaNET01188",
+                  "http://purl.org/pan-science/PaNET/PaNET01282",
+                  "http://purl.org/pan-science/PaNET/PaNET01281",
+                  "http://purl.org/pan-science/PaNET/PaNET01273",
+                  "http://purl.org/pan-science/PaNET/PaNET01279",
+                  "http://purl.org/pan-science/PaNET/PaNET01280",
+                  "http://purl.org/pan-science/PaNET/PaNET01107",
+                  "http://purl.org/pan-science/PaNET/PaNET01162",
+                  "http://purl.org/pan-science/PaNET/PaNET01286",
+                  "http://purl.org/pan-science/PaNET/PaNET01287",
+                  "http://purl.org/pan-science/PaNET/PaNET01241",
+                  "http://purl.org/pan-science/PaNET/PaNET01240"
+                ]
+              }
+            },
+            {
+              "pid" : {
+                "nin": [
+                  "http://purl.org/pan-science/PaNET/PaNET00207",
+                  "http://purl.org/pan-science/PaNET/PaNET01313",
+                  "http://purl.org/pan-science/PaNET/PaNET01143",
+                  "http://purl.org/pan-science/PaNET/PaNET01301",
+                  "http://purl.org/pan-science/PaNET/PaNET01137",
+                  "http://purl.org/pan-science/PaNET/PaNET01221",
+                  "http://purl.org/pan-science/PaNET/PaNET01142",
+                  "http://purl.org/pan-science/PaNET/PaNET01259",
+                  "http://purl.org/pan-science/PaNET/PaNET01252",
+                  "http://purl.org/pan-science/PaNET/PaNET01141",
+                  "http://purl.org/pan-science/PaNET/PaNET01253"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Dataset returned
+*PID.SAMPLE.PREFIX/dls_ds1 , PID.SAMPLE.PREFIX/dls_ds2 , PID.SAMPLE.PREFIX/hzdr_ds1 , PID.SAMPLE.PREFIX/maxiv_ds2 , PID.SAMPLE.PREFIX/ukri_ds5 , PID.SAMPLE.PREFIX/ukri_ds6*
+
+
+\
+Query details: 
+- techniques highlighted with **bold** are the ones matching the first operand of the logical and in the query, 
+- techniques highlighted with ~~strikethrough~~ are the ones matching the second operand of the logical and in the query. They need not to be present in order for the dataset to be selected
+- techniques highlighted with ~~**bold and strikethrought**~~ are the ones matching both the first and second operand of the logical and in the query,
+ 
+ | Selected | Dataset id | Technique Name | Technique PID |
+ | :-: | - | - | - |
+ |   | PID.SAMPLE.PREFIX/desy_ds1 | resonant inelastic x-ray scattering | http://purl.org/pan-science/PaNET/PaNET01183 | 
+ |   | PID.SAMPLE.PREFIX/desy_ds2 | resonant inelastic x-ray scattering	| http://purl.org/pan-science/PaNET/PaNET01183 |
+ |   | PID.SAMPLE.PREFIX/desy_ds3 | resonant inelastic x-ray scattering	| http://purl.org/pan-science/PaNET/PaNET01183 |
+ | Y | PID.SAMPLE.PREFIX/dls_ds1 | **anomalous solution x-ray scattering**	| **http://purl.org/pan-science/PaNET/PaNET01275** |
+ | Y | PID.SAMPLE.PREFIX/dls_ds2 | **grazing incidence small angle x-ray scattering**	| **http://purl.org/pan-science/PaNET/PaNET01162** |
+ | Y | PID.SAMPLE.PREFIX/hzdr_ds1 | **inelastic x-ray small angle scattering**	| **http://purl.org/pan-science/PaNET/PaNET01281** |
+ |   | PID.SAMPLE.PREFIX/maxiv_ds1 | resonant inelastic x-ray scattering | http://purl.org/pan-science/PaNET/PaNET01183 |
+ | Y | PID.SAMPLE.PREFIX/maxiv_ds2 | **soft x-ray small angle scattering**	| **http://purl.org/pan-science/PaNET/PaNET01282** |
+ |   | PID.SAMPLE.PREFIX/psi_ds1 | ~~magnetic x-ray tomography~~	| ~~http://purl.org/pan-science/PaNET/PaNET01313~~ |
+ |   | PID.SAMPLE.PREFIX/psi_ds2 | ~~magnetic x-ray tomography~~  | ~~http://purl.org/pan-science/PaNET/PaNET01313~~ |
+ |   | PID.SAMPLE.PREFIX/psi_ds3 | ~~magnetic x-ray tomography~~  | ~~http://purl.org/pan-science/PaNET/PaNET01313~~ |
+ |   | PID.SAMPLE.PREFIX/soleil_ds1 | x-ray emission spectroscopy  | http://purl.org/pan-science/PaNET/PaNET01200 |
+ |   | PID.SAMPLE.PREFIX/soleil_ds2 | x-ray emission spectroscopy  | http://purl.org/pan-science/PaNET/PaNET01200 |
+ |   | PID.SAMPLE.PREFIX/ukri_ds1 | x-ray emission spectroscopy ,<br /> ~~magnetic x-ray tomography~~ | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> ~~http://purl.org/pan-science/PaNET/PaNET01313~~ |
+ |   | PID.SAMPLE.PREFIX/ukri_ds2 | x-ray emission spectroscopy ,<br /> ~~magnetic x-ray tomography~~ | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> ~~http://purl.org/pan-science/PaNET/PaNET01313~~ |
+ |   | PID.SAMPLE.PREFIX/ukri_ds3 | x-ray emission spectroscopy ,<br /> ~~magnetic x-ray tomography~~ | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> ~~http://purl.org/pan-science/PaNET/PaNET01313~~ |
+ |   | PID.SAMPLE.PREFIX/ukri_ds4 | x-ray emission spectroscopy ,<br /> ~~magnetic x-ray tomography~~ | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> ~~http://purl.org/pan-science/PaNET/PaNET01313~~ |
+ |   | PID.SAMPLE.PREFIX/ukri_ds5 | x-ray emission spectroscopy ,<br /> **grazing incidence small angle scattering** | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> **http://purl.org/pan-science/PaNET/PaNET01162** |
+ |   | PID.SAMPLE.PREFIX/ukri_ds6 | x-ray emission spectroscopy ,<br /> **anomalous solution x-ray scattering** | http://purl.org/pan-science/PaNET/PaNET01200 ,<br /> **http://purl.org/pan-science/PaNET/PaNET01275** |
+
+
+#### Status
+*verified* and *validate*
+
+
+## Credits
+This document has been prepared by Massimiliano (Max) Novelli (max.novelli@ess.eu) while testing the techiniques functionalities during the approval process of the github PR.

--- a/server/model-config.json
+++ b/server/model-config.json
@@ -73,7 +73,7 @@
     "public": false
   },
   "Technique": {
-    "dataSource": null,
+    "dataSource": "db",
     "public": false
   }
 }

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -1,0 +1,113 @@
+"use strict";
+
+const expect = require("chai").expect;
+const sandbox = require("sinon").createSandbox();
+
+const loopbackCache = require("../common/cache").LoopbackCache;
+
+let app;
+before((done) => {
+  app = require("../server/server");
+  done();
+});
+
+afterEach((done) => {
+  sandbox.restore();
+  done();
+});
+
+describe("LoopbackCache", () => {
+  const cache = new loopbackCache(
+    { sttl: 10, collection: "Technique" }
+  );
+  describe("set", () => {
+    const tests = [
+      {
+        args: { input: [{ name: "a", pid: 1 }], ttl: 100 },
+        expected: { name: "a", pid: 1, ttl: 100 },
+        message: "array"
+      },
+      {
+        args: { input: [{ name: "a", pid: 1 }], ttl: 100 },
+        expected: { name: "a", pid: 1, ttl: 100 },
+        message: "object"
+      },
+      {
+        args: {
+          input: function* gen(input) { yield input; }(
+            { name: "b", pid: 2, createdAt: 100 }
+          ),
+          ttl: 0
+        },
+        expected: { name: "b", pid: 2, ttl: 0, createdAt: 100 },
+        message: "generator"
+      }
+    ];
+    tests.forEach(({ args, expected, message }) => {
+      context(
+        `Stores the ${message} in the loopback datasource`,
+        () => {
+          it(`${message}`,
+            (done) => {
+              const mock = sandbox.stub(app.models[cache.collection],
+                "upsert");
+              cache.set(null, args.input, args.ttl).then(() => {
+                expect(mock.calledWith(expected)).to.be.true;
+              });
+              done();
+            });
+        }
+      );
+    });
+  });
+
+  describe("get", () => {
+    const tests = [
+      {
+        args: { where: { name: "a" } },
+        expected: [{ name: "a", pid: "1", ttl: 100, createdAt: 10 }],
+        message: "non empty"
+      },
+      {
+        args: { where: { name: "c" } },
+        expected: [],
+        message: "empty"
+      },
+      {
+        args: { where: { name: "b" } },
+        expected: "destroyAll",
+        message: "expired"
+      }
+    ];
+    tests.forEach(({ args, expected, message }) => {
+      context(
+        `${message} cache due to filter`,
+        () => {
+          it(`${message}`,
+            (done) => {
+              const mockFind = sandbox.stub(app.models[cache.collection],
+                "find");
+              sandbox.stub(Date, "now").returns(10);
+              if (expected === "destroyAll") {
+                mockFind.returns([{ name: "b", pid: 2, createdAt: 0, ttl: 0 }]);
+                const mock = sandbox.spy(app.models[cache.collection],
+                  expected);
+                cache.get(args).then(() => expect(
+                  mock.calledWith(args.where)).to.be.true);
+              } else if (expected.length > 0) {
+                mockFind.returns(expected);
+                cache.get(args).then(data =>
+                  expect(data[0]).to.be.eql(expected[0]));
+              } else {
+                mockFind.returns(expected);
+                cache.get(args).then(data =>
+                  expect(data).to.be.eql(expected));
+              }
+              done();
+            });
+        }
+      );
+    });
+  });
+
+});

--- a/test/technique-filter-builder.test.js
+++ b/test/technique-filter-builder.test.js
@@ -2,7 +2,6 @@
 
 const expect = require("chai").expect;
 const sandbox = require("sinon").createSandbox();
-const utils = require("../common/utils");
 
 const BioPortalLoopbackCacheBuilder = require(
   "../common/technique-filter-builder").BioPortalLoopbackCacheBuilder;
@@ -121,7 +120,6 @@ describe("BioPortalLoopbackCacheBuilder", () => {
         the intersection of relatives`,
         (done) => {
           const args = [{ name: "a", pid: 1 }, { pid: 2 }];
-          const expected = [2, 1];
           const mock = sandbox.stub(
             techniqueCache, "buildTechniques").onCall(0).returns([
             { relatives: [1, 2] },
@@ -130,7 +128,10 @@ describe("BioPortalLoopbackCacheBuilder", () => {
             { relatives: [2, 5] },
             { relatives: [1, 7] }]
           );
-          const spy = sandbox.spy(utils, "intersectArraysOfObjects");
+          const expected = { and: [
+            { pid: { inq: [1, 2, 3, 4] } },
+            { pid: { inq: [2, 5, 1, 7] } }
+          ] };
           techniqueCache.and(args).then(
             data => {
               expect(data).to.be.eql(expected);
@@ -141,13 +142,6 @@ describe("BioPortalLoopbackCacheBuilder", () => {
                 ]
               })).to.true;
               expect(mock.getCall(1).calledWith({ pid: 2 })).to.true;
-              expect(spy.calledWith(
-                [
-                  { relatives: [2, 5, 1, 7] },
-                  { relatives: [1, 2, 3, 4] }
-                ],
-                "relatives"
-              )).to.true;
             });
           done();
         }

--- a/test/technique-filter-builder.test.js
+++ b/test/technique-filter-builder.test.js
@@ -1,0 +1,225 @@
+"use strict";
+
+const expect = require("chai").expect;
+const sandbox = require("sinon").createSandbox();
+const utils = require("../common/utils");
+
+const BioPortalLoopbackCacheBuilder = require(
+  "../common/technique-filter-builder").BioPortalLoopbackCacheBuilder;
+
+afterEach((done) => {
+  sandbox.restore();
+  done();
+});
+
+describe("BioPortalLoopbackCacheBuilder", () => {
+  const techniqueCache = new BioPortalLoopbackCacheBuilder(
+    {
+      url: "http://aUrl.com", apiKey: "aKey",
+      cache: { sttl: 10, collection: "Technique" }
+    });
+
+  describe("prepareForCache", () => {
+    context(
+      `Tranforms an object with the structure of BioPortalTechniques to
+          a format that can be used by LoopbackCache`,
+      () => {
+        it("A generator with a format that can be used by LoopbackCache",
+          (done) => {
+            const args = {
+              nodes: { relatives: { 1: new Set([2, 3]), 2: new Set([3, 4]) } },
+              collection: [
+                { "@id": 1, prefLabel: "a", synonym: ["A"], aField: "f" },
+                { "@id": 2, prefLabel: "b", synonym: ["B"] }]
+            };
+            const expected = [
+              {
+                pid: 1, name: "a", synonym: ["A"],
+                relatives: [2, 3], createdAt: "now"
+              },
+              {
+                pid: 2, name: "b", synonym: ["B"],
+                relatives: [3, 4], createdAt: "now"
+              }
+            ];
+
+            sandbox.stub(Date, "now").returns("now");
+
+            const results = [];
+            for (var result of techniqueCache.constructor.prepareForCache(args))
+              results.push(result);
+            expect(results).to.be.eql(expected);
+            done();
+          });
+      }
+    );
+  });
+
+  describe("createSynonym", () => {
+    const tests = [{
+      args: { name: "a", pid: 1 },
+      expected: { synonym: "a", pid: 1 },
+      message: "replacing name with synonym"
+    },
+    {
+      args: { pid: 2 },
+      expected: null,
+      message: "returning null as NAME key is missing"
+    }
+    ];
+    tests.forEach(({ args, expected, message }) => {
+      context(
+        `Returns the same filter structure used by the NAME field, ${message}`,
+        () => {
+          it(`${message}`,
+            (done) => {
+              expect(
+                techniqueCache.constructor.createSynonym(args)).to.be.eql(
+                expected);
+              done();
+            });
+        }
+      );
+    });
+  });
+
+  describe("flat", () => {
+    context(
+      `Starting from loopback filter it adds synonym to it and returns the
+      relatives`,
+      () => {
+        it(`Object the filter + synonym, joined by an OR condition, and returns
+        the relatives`,
+        (done) => {
+          const args = { name: "a", pid: 1 };
+          const expected = [1, 2, 3, 4];
+          const mock = sandbox.stub(techniqueCache,
+            "buildTechniques").returns([
+            { relatives: [1, 2] },
+            { relatives: [3, 4] }]);
+          techniqueCache.flat(args).then(
+            data => {
+              expect(data).to.be.eql(expected);
+              expect(mock.calledWith({
+                or: [
+                  { name: "a", pid: 1 },
+                  { synonym: "a", pid: 1 }]
+              })).to.true;
+            });
+          done();
+        }
+        );
+      });
+  });
+
+  describe("and", () => {
+    context(
+      `Starting from loopback AND filter it adds synonym to it and returns the
+      intersection of relatives`,
+      () => {
+        it(`Object the filter + synonym, joined by an OR condition, and returns
+        the intersection of relatives`,
+        (done) => {
+          const args = [{ name: "a", pid: 1 }, { pid: 2 }];
+          const expected = [2, 1];
+          const mock = sandbox.stub(
+            techniqueCache, "buildTechniques").onCall(0).returns([
+            { relatives: [1, 2] },
+            { relatives: [3, 4] }]
+          ).onCall(1).returns([
+            { relatives: [2, 5] },
+            { relatives: [1, 7] }]
+          );
+          const spy = sandbox.spy(utils, "intersectArraysOfObjects");
+          techniqueCache.and(args).then(
+            data => {
+              expect(data).to.be.eql(expected);
+              expect(mock.getCall(0).calledWith({
+                or: [
+                  { name: "a", pid: 1 },
+                  { synonym: "a", pid: 1 }
+                ]
+              })).to.true;
+              expect(mock.getCall(1).calledWith({ pid: 2 })).to.true;
+              expect(spy.calledWith(
+                [
+                  { relatives: [2, 5, 1, 7] },
+                  { relatives: [1, 2, 3, 4] }
+                ],
+                "relatives"
+              )).to.true;
+            });
+          done();
+        }
+        );
+      });
+  });
+
+  describe("buildFilter", () => {
+    const tests = [
+      {
+        args: { and: { name: "a", pid: 1 } },
+        expected: "and",
+        message: "AND"
+      },
+      {
+        args: { or: { name: "a", pid: 1 } },
+        expected: "or",
+        message: "OR"
+      },
+      {
+        args: { name: "a", pid: 1 },
+        expected: "flat",
+        message: "FLAT"
+      }
+    ];
+    tests.forEach(({ args, expected, message }) => {
+      context(
+        `Returns Loopback filter with relatives from ${message} filtered
+        LoopbacCache or BioPortal in INQ clause`,
+        () => {
+          it(`${message}`,
+            (done) => {
+              const mock = sandbox.stub(techniqueCache, expected).returns([]);
+              techniqueCache.buildFilter(args).then(() =>
+                expect(mock.callCount).to.be.eql(1)
+              );
+              done();
+            });
+        }
+      );
+    });
+  });
+
+  describe("buildTechniques", () => {
+    context(
+      "Builds the items from filtered LoopbacCache or BioPortal",
+      () => {
+        it("Array of objects from filtered LoopbacCache or BioPortal",
+          (done) => {
+            const args = { name: "a", pid: 1 };
+            sandbox.stub(techniqueCache.techniqueGetter, "build");
+            techniqueCache.techniqueGetter.nodes = { relatives: { 1: [1, 2] } };
+            techniqueCache.techniqueGetter.collection = [{
+              "@id": 1, prefLabel: "a", synonym: ["A"], aField: "f"
+            }];
+            const expected = {
+              pid: 1, name: "a", synonym: ["A"],
+              relatives: [1, 2], createdAt: 10
+            };
+            sandbox.stub(Date, "now").returns(10);
+            sandbox.stub(techniqueCache.cache, "get").returns([]);
+            const mock = sandbox.stub(techniqueCache.cache, "set");
+            techniqueCache.buildTechniques(args).then(
+              () => {
+                expect(mock.args[0][1].next().value
+                ).to.be.eql(expected);
+              }
+            );
+            done();
+          });
+      }
+    );
+  });
+
+});

--- a/test/technique-getter.test.js
+++ b/test/technique-getter.test.js
@@ -1,0 +1,264 @@
+"use strict";
+
+const expect = require("chai").expect;
+const sandbox = require("sinon").createSandbox();
+const superagent = require("superagent");
+
+
+const BioPortalTechniques = require(
+  "../common/technique-getter").BioPortalTechniques;
+afterEach((done) => {
+  sandbox.restore();
+  done();
+});
+
+describe("BioPortalTechniques", () => {
+  const technique = new BioPortalTechniques(
+    { url: "http://aUrl.com", apiKey: "aKey" });
+  describe("composeURL", () => {
+    context(
+      "Sets the url, the queryParams and the headers to use",
+      () => {
+        it("Sets the url, the queryParams and the headers to use", (done) => {
+          technique.composeURL();
+          expect(technique.url instanceof URL).to.true;
+          expect(technique.headers).to.not.be.null;
+          expect(technique.queryParams).to.not.be.null;
+          done();
+        });
+      }
+    );
+  });
+
+
+  describe("prefLabel", () => {
+    context(
+      "Returns the item with extra spaces removed",
+      () => {
+        it("Item with extra spaces removed", (done) => {
+          const args = "a bb     cc d";
+          const expected = "a bb cc d";
+          expect(technique.constructor.prefLabel(args)).to.be.eql(expected);
+          done();
+        });
+      }
+    );
+  });
+
+  describe("synonym", () => {
+    context(
+      "Returns the item removing extra spaces",
+      () => {
+        it("Item removing extra spaces", (done) => {
+          const args = ["b", "c  d    e"];
+          const expected = ["b", "c d e"];
+          expect(technique.constructor.synonym(args)).to.be.eql(expected);
+          done();
+        });
+      }
+    );
+  });
+
+  describe("children", () => {
+    context(
+      "Returns the item unpacking the array of objects",
+      () => {
+        it("Item unpacking the array of objects", (done) => {
+          const args = [{ "@id": 1 }, { "@id": 2 }];
+          const expected = [1, 2];
+          expect(technique.constructor.children(args)).to.be.eql(expected);
+          done();
+        });
+      }
+    );
+  });
+
+  describe("parents", () => {
+    context(
+      "Returns the item unpacking the array of objects",
+      () => {
+        it("Item unpacking the array of objects", (done) => {
+          const args = [
+            { prefLabel: null, "@id": 1 },
+            { prefLabel: null, "@id": 2 }
+          ];
+          const expected = [];
+          expect(technique.constructor.parents(args)).to.be.eql(expected);
+          done();
+        });
+      }
+    );
+  });
+
+
+  describe("processCollection", () => {
+    context(
+      "Returns a generator with processed lines",
+      () => {
+        it("Generator with  processed lines", (done) => {
+          const args = [
+            {
+              prefLabel: "a",
+              pid: 1,
+              synonym: ["aa    b b", "c"],
+              children: [{ "@id": 1 }, { "@id": 2 }],
+              parents: [
+                { prefLabel: null, "@id": 3 }, { prefLabel: "d", "@id": 4 }]
+            }
+          ];
+          const expected = [
+            {
+              prefLabel: "a",
+              pid: 1,
+              synonym: ["aa b b", "c"],
+              children: [1, 2],
+              parents: [3, 4]
+            }
+          ];
+          const results = [];
+          for (var result of technique.processCollection(args))
+            results.push(result);
+          expect(results).to.be.eql(expected);
+          expect(technique.collection).to.be.eql(expected);
+          done();
+        });
+      }
+    );
+  });
+
+  describe("buildNodes", () => {
+    context(
+      `Creates an object where firstKey is the type of object and as value a
+      second object with an id and the value`,
+      () => {
+        it(`Object where firstKey is the type of object and as value a second
+        object with an id and the value`, (done) => {
+          const args = [
+            {
+              prefLabel: "a",
+              "@id": 1,
+              synonym: ["aa", "c"],
+              children: [],
+              parents: [3, 4]
+            },
+            {
+              prefLabel: "b",
+              "@id": 2,
+              synonym: [],
+              children: [1, 2],
+              parents: []
+            }
+          ];
+          const expected = {
+            names: { 1: "a", 2: "b" },
+            "@id": { a: 1, b: 2 },
+            children: { 1: [], 2: [1, 2] },
+            parents: { 1: [3, 4], 2: [] },
+            synonym: { 1: ["aa", "c"], 2: [] },
+            synonymT: { "aa": 1, "c": 1 },
+            leaves: [1],
+            roots: [2]
+          };
+          expect(technique.constructor.buildNodes(args)).to.be.eql(expected);
+          done();
+        });
+      }
+    );
+  });
+
+  describe("getCollection", () => {
+    context(
+      "Concats together the responses of BioPortal from different pages",
+      async () => {
+        it("Responses of BioPortal from different pages", (done) => {
+          const stubReturn = {
+            query: () => {
+              return {
+                set: () => {
+                  return new Promise((resolve) => {
+                    resolve({ text: "{\"collection\":[1,2],\"pageCount\":4}" });
+                  });
+                }
+              };
+            }
+          };
+          const mock = sandbox
+            .stub(superagent, "get");
+          mock.returns(stubReturn);
+          technique.getCollection().then(
+            () => expect(mock.callCount).to.be.eql(4)
+          );
+          done();
+        });
+      }
+    );
+  });
+
+  describe("build", () => {
+    context(
+      `Builds and sets a graph with key the id of the BioPortal item and value
+      the relatives (ancestor or descendants)`,
+      () => {
+        it(`Sets a graph with key the id of the BioPortal item and value the 
+        relatives (ancestor or descendants)`, (done) => {
+          const args = [
+            {
+              prefLabel: " a ",
+              "@id": 1,
+              synonym: [" A "],
+              children: [{ "@id": 2 }],
+              parents: [
+                { prefLabel: null, "@id": null },
+                { prefLabel: null, "@id": null }]
+            },
+            {
+              prefLabel: "b",
+              "@id": 2,
+              synonym: [],
+              children: [],
+              parents: [{ prefLabel: "a", "@id": 1 }]
+            }
+          ];
+          const expected = {
+            nodes: {
+              names: { 1: "a", 2: "b" },
+              "@id": { a: 1, b: 2 },
+              children: { 1: [2], 2: [] },
+              parents: { 1: [], 2: [1] },
+              synonym: { 1: ["A"], 2: [] },
+              synonymT: { "A": 1 },
+              leaves: [2],
+              roots: [1],
+              relatives: { 1: new Set([1, 2]), 2: new Set([2]) }
+            },
+            collection:
+              [
+                {
+                  prefLabel: "a",
+                  "@id": 1,
+                  synonym: ["A"],
+                  children: [2],
+                  parents: []
+                },
+                {
+                  prefLabel: "b",
+                  "@id": 2,
+                  synonym: [],
+                  children: [],
+                  parents: [1]
+                }
+              ]
+          };
+          sandbox.stub(technique, "getCollection").resolves(
+            args);
+          technique.build().then(data => {
+            expect(data.collection).to.be.eql(expected.collection);
+            expect(data.nodes).to.be.eql(expected.nodes);
+          });
+          done();
+        });
+      }
+    );
+  });
+
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -425,26 +425,4 @@ describe("utils", () => {
     );
   });
 
-  describe("intersectArraysOfObjects", () => {
-    context(
-      `Creates an object with key keyOfObject and value of arrays containing
-      the intersection of the object keyOfObject property`,
-      () => {
-        it(`Object with key keyOfObject and value of arrays containing the
-        intersection of the object keyOfObject property`, (done) => {
-          const input = [
-            { key: [123, 456, 789, "abc", "abc"] },
-            { key: ["abc", "def", 123] },
-            { key: ["abc", "ghi", 123] }
-          ];
-          const expected = {
-            key: [123, "abc"]
-          };
-          expect(utils.intersectArraysOfObjects(input, "key")).to.eql(expected);
-          done();
-        });
-      }
-    );
-  });
-
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -273,4 +273,178 @@ describe("utils", () => {
       }
     );
   });
+
+  describe("buildTree", () => {
+    const tests = [
+      {
+        args: {
+          node: "a", relatives: {
+            a: ["b", "c"],
+            b: ["d"],
+            c: ["d", "e"],
+            d: [],
+            e: ["f"],
+            f: []
+          }, ids: {}, tree: {}
+        },
+        expected: {
+          a: new Set(["a"]),
+          b: new Set(["a", "b"]),
+          c: new Set(["a", "c"]),
+          d: new Set(["a", "b", "c", "d"]),
+          e: new Set(["a", "c", "e"]),
+          f: new Set(["a", "c", "e", "f"]),
+        },
+        message: "a tree without using id mapping ",
+      },
+      {
+        args: {
+          node: "a", relatives: {
+            a: ["b", "c"],
+            b: ["d"],
+            c: ["d", "e"],
+            d: [],
+            e: ["f"],
+            f: []
+          },
+          ids: { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 },
+          tree: {}
+        },
+        expected: {
+          a: new Set([1]),
+          b: new Set([1, 2]),
+          c: new Set([1, 3]),
+          d: new Set([1, 2, 3, 4]),
+          e: new Set([1, 3, 5]),
+          f: new Set([1, 3, 5, 6]),
+        },
+        message: "a tree using id mapping ",
+      },
+      {
+        args: {
+          node: "a", relatives: {
+            a: ["b", "c"],
+            b: ["d"],
+            c: ["d", "e"],
+            d: [],
+            e: ["f"],
+            f: []
+          }, ids: {}, tree: { z: 100 }
+        },
+        expected: {
+          a: new Set(["a"]),
+          b: new Set(["a", "b"]),
+          c: new Set(["a", "c"]),
+          d: new Set(["a", "b", "c", "d"]),
+          e: new Set(["a", "c", "e"]),
+          f: new Set(["a", "c", "e", "f"]),
+          z: 100
+        },
+        message: "a tree using a preexisting tree object",
+      },
+    ];
+    tests.forEach(({ args, expected, message }) => {
+      context(`${message}`, () => {
+        it(`should return a ${message}`, (done) => {
+          expect(utils.buildTree(args.node,
+            args.relatives,
+            args.ids,
+            args.tree)).to.eql(expected);
+          done();
+        });
+      });
+    });
+  });
+
+  describe("buildForest", () => {
+    context(
+      "Creates an object with the node as a key and the list ancestors as value",
+      () => {
+        it("Object with the node as a key and the list ancestors as value",
+          (done) => {
+            const args = {
+              startList: ["a", "q", "z"],
+              relatives: {
+                a: ["b", "c"],
+                b: ["d"],
+                c: ["d"],
+                d: [],
+                q: ["p"],
+                p: ["c"],
+                z: ["b", "p"]
+              }
+            };
+            const expected = {
+              a: new Set(["a"]),
+              b: new Set(["a", "b", "z"]),
+              c: new Set(["a", "c", "p", "q", "z"]),
+              d: new Set(["a", "b", "c", "d", "p", "q", "z"]),
+              p: new Set(["q", "p", "z"]),
+              q: new Set(["q"]),
+              z: new Set(["z"]),
+            };
+            expect(utils.buildForest(
+              args.startList,
+              args.relatives)).to.eql(expected);
+            done();
+          });
+      }
+    );
+  });
+
+  describe("range", () => {
+    context(
+      "Creates a list of integers included in [start, end]",
+      () => {
+        it("List of integers included in [start, end]", (done) => {
+          expect(utils.range(5, 10)).to.eql([5, 6, 7, 8, 9, 10]);
+          done();
+        });
+      }
+    );
+  });
+
+  describe("unionArraysOfObjects", () => {
+    context(
+      `Creates an object with key keyOfObject and value of arrays containing
+      the union of the object keyOfObject property`,
+      () => {
+        it(`Object with key keyOfObject and value of arrays containing the
+        union of the object keyOfObject property`, (done) => {
+          const input = [
+            { key: [123, 456, 789] },
+            { key: ["abc", "def"] }
+          ];
+          const expected = {
+            key: [123, 456, 789, "abc", "def"]
+          };
+          expect(utils.unionArraysOfObjects(input, "key")).to.eql(expected);
+          done();
+        });
+      }
+    );
+  });
+
+  describe("intersectArraysOfObjects", () => {
+    context(
+      `Creates an object with key keyOfObject and value of arrays containing
+      the intersection of the object keyOfObject property`,
+      () => {
+        it(`Object with key keyOfObject and value of arrays containing the
+        intersection of the object keyOfObject property`, (done) => {
+          const input = [
+            { key: [123, 456, 789, "abc", "abc"] },
+            { key: ["abc", "def", 123] },
+            { key: ["abc", "ghi", 123] }
+          ];
+          const expected = {
+            key: [123, "abc"]
+          };
+          expect(utils.intersectArraysOfObjects(input, "key")).to.eql(expected);
+          done();
+        });
+      }
+    );
+  });
+
 });


### PR DESCRIPTION
## Description

Attempt in implementing the technique logic. 3 components are added: 

- technique-getter -> it is a class to get the techniques list and build a graph of descendants from Bioportla
- cache -> a class to set and get the afore-created techniques graph to loopback db
- technique-filter-builder -> a class that does the formatting to store the techniques to the cache and implements the retrieval logic based on the input loopback filter. Based on different conditions on the filter, "or, and, plain" it implements different logics that format the input filter to one forwarded to the datacatalogue be. 

The use of these particular classes depend on the configuration set up, in particular, once the caching layer and the technique-getter class is specified, the technique-filter-builder is automatically inferred as it depends on the choice of the others. If no configuration is provided, it defaults to the existing logic (before this PR). Example of config.json file, to be added to the root of the project: 
```
{
  "technique": {
    "class": "BioPortalTechniques",
    "url": "https://data.bioontology.org/ontologies/PANET/classes",
    "apiKey": <BIOPORTAL_APIKEY>,
    "cache": {
      "class": "LoopbackCache",
      "sttl": 30, // cache timeout in seconds
      "collection": "Technique"
    }
  }
}
```
Sketch of the data flow in the proposed implementation:
![image](https://user-images.githubusercontent.com/50220438/138483500-1fb06647-391c-41f2-8cf4-68186f32289e.png)

### Detailed data flow:
1. An end-user, using the loopback query format, inputs a set of techniques she is interested in. Such a query could look like this (added to the filter value of GET Datasests endpoint, [e.g](https://github.com/panosc-eu/search-api/blob/master/doc/dataset-example-queries.md)):

```
{
        "include": [
            {
                "relation": "techniques",
                "scope": {
                    "where": {
                        "and": [
                            {
                                "name": "small angle scattering"
                            },
                            {
                                "name": "x-ray probe"
                            }
                        ]
                    }
                }
            }
        ]
    }
```

2 . The search-api will now call Bioportal (or the cache) and get these two techniques with their descendants, as shown here respectively:
![small_angle_scattering_int](https://user-images.githubusercontent.com/50220438/138480819-5d0a9fc2-5a6e-4e48-9750-4029543682ed.png)
![x-ray_probe_int](https://user-images.githubusercontent.com/50220438/138480827-32c4efb9-46cc-4e7b-b1e1-e9c306a5a7b8.png)

3. and compute the intersection of the descendants, returning only the common ones (in red).
The same filter with an OR condition will return the union of descendants, as opposed to the intersection, and when querying one single technique it will simply return the list of descendants.

4. This list of descendants from BioPortal, each with its own PID, is sent to the be (catamel), using this query, in the GET Datasets endpoint of catamel:
```
{
"where": {
   "techniques.pid": {"inq": ["pid1, pid2, pid3,..."]}
}
```
5. Thus all datasets in the data catalogue having at least one of these PIDs in the TechniquesList field are returned and displayed to the user.

As a general recommendation, datasets are to be labelled with the most specific technique possible, so that the results can be as fine-grained as possible

## Motivation

Attempt in implementing the technique logic. The use case is of an end-user who is willing to filter datasets based on techniques. Based on the assumption that the technique field in the datasets is labelled with the most granular information available, the logic implemented here manipulates the filter input by the end-user to a format that the datacatalogue be can interpret. For example, the end-user could select multiple labels when filtering and the logic here combines these labels returning the descendants which descend only from both. It then forwards the PIDs of the descendants to the datacatalogue be.

## Changes:

* technique-getter -> created
* cache -> created
* technique-filter-builder -> created
* utils -> method added to cover operations on graphs and sets
* datamodel -> slightly modified to serve as cache
* response-mapper, filter-mapper, dataset -> modified to allow async call and include the three classes on top

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [x] Toggle added for new features?
