### PR TITLE
Pans

### DIFF
--- a/common/filter-mapper.js
+++ b/common/filter-mapper.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const PanetOntology = require("../common/panet-service").PanetOntology;
 const mappings = require("./mappings");
 const utils = require("./utils");
 
@@ -31,6 +32,8 @@ exports.dataset = async (filter) => {
         (inclusion) => inclusion.relation === "techniques"
       );
       if (techniques && techniques.scope && techniques.scope.where) {
+        techniques.scope.where = await PanetOntology.panet(
+          techniques.scope.where);
         scicatFilter = mapField(techniques, scicatFilter);
       }
       const include = filter.include

--- a/common/panet-service.js
+++ b/common/panet-service.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const superagent = require("superagent");
+
+class Panet {
+
+  constructor(baseUrl) {
+    this.panetUrl = baseUrl + "/techniques/pan-ontology";
+  }
+
+  /**
+   * request panet ontology to pan-ontologies service
+   * @param {object} techniqueLoopbackWhere Loopback where filter with condition
+   *  on a field of the technique model
+   * @returns {object} Loopback where filter made of condition on list of pids:
+   * e.g {and:[{pid:{inq: [1,2,3]}, {pid: {inq: [4,5,6]}}]}
+   * or {or:[{pid:{inq: [1,2,3]}, {pid: {inq: [4,5,6]}}]}
+   * or {pid:{inq: [1,2,3]}}
+   */
+  async panet(techniqueLoopbackWhere) {
+
+    console.log(">>> Panet.panet: panet requested");
+    console.log(" - where filter : ", techniqueLoopbackWhere);
+
+    const res = await superagent
+      .get(this.panetUrl)
+      .query({ where: JSON.stringify(techniqueLoopbackWhere) });
+    return JSON.parse(res.text);
+  }
+
+}
+
+exports.PanetOntology = process.env.PANET_BASE_URL ?
+  new Panet(process.env.PANET_BASE_URL) :
+  { panet: (techniqueLoopbackWhere) => techniqueLoopbackWhere };

--- a/test/panet-service.test.js
+++ b/test/panet-service.test.js
@@ -1,0 +1,45 @@
+"use strict";
+
+const expect = require("chai").expect;
+const superagent = require("superagent");
+
+describe("PanetOntology", () => {
+  let sandbox;
+  let panet;
+  const env = Object.assign({}, process.env);
+
+  before(() => {
+    sandbox = require("sinon").createSandbox();
+  });
+
+  beforeEach(() => {
+    delete require.cache[require.resolve("../common/panet-service")];
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    process.env = env;
+  });
+
+  after(() => {
+    delete require.cache[require.resolve("../common/panet-service")];
+    require("../common/panet-service");
+  });
+
+  it("Panet", async () => {
+    process.env.PANET_BASE_URL = "http://a-url";
+    panet = require("../common/panet-service").PanetOntology;
+    sandbox.stub(superagent, "get").returns(
+      { query: async () => ({ text: "{\"pid\": [\"1\",\"2\",\"3\"]}" }) });
+    const res = await panet.panet({ name: "aTechnique" });
+    expect(res).to.be.eql({ pid: ["1", "2", "3"] });
+  });
+
+  it("Undefined PANET_BASE_URL", () => {
+    delete process.env.PANET_BASE_URL;
+    panet = require("../common/panet-service").PanetOntology;
+    expect(
+      panet.panet({ name: "aTechnique" })).to.be.eql({ name: "aTechnique" });
+  });
+
+});


### PR DESCRIPTION
## Description

Set a flag on which technique builder endpoint to use. If nothing is provided, no external endpoint is called. The env variable to set is BASE_PANET_URL. If this is set to the URL of the pan-ontologies-api, the endpoint returns a new loopback where condition, having translated the input from the user to a list of pids.

## Motivation

Instead of implementing the logic here, a new ms was created and the panet logic is fetch from there

## Changes:

* Create a new class panet-service and an instance of it depending on the env variable PANET_BASE_URL
* plug it in in the filter-mapper file
* add tests

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [x] Toggle added for new features?
