### PR TITLE
Swap 2554

### DIFF
--- a/common/panet-service.js
+++ b/common/panet-service.js
@@ -22,13 +22,25 @@ class Panet {
     console.log(">>> Panet.panet: panet requested");
     console.log(" - where filter : ", techniqueLoopbackWhere);
 
-    const res = await superagent
-      .get(this.panetUrl)
-      .query({ where: JSON.stringify(techniqueLoopbackWhere) });
+    // const res = await superagent
+    //   .get(this.panetUrl)
+    //   .query({ where : JSON.stringify(techniqueLoopbackWhere) });
 
-    const newTechniqueLoopbackWhere = JSON.parse(res.text);
-    console.log(" - where filter : ", newTechniqueLoopbackWhere);
-    return newTechniqueLoopbackWhere;
+    // const newTechniqueLoopbackWhere = JSON.parse(res.text);
+    // console.log(" - where filter : ", newTechniqueLoopbackWhere);
+    // return newTechniqueLoopbackWhere;
+
+    return superagent
+      .get(this.panetUrl)
+      .query({ where : JSON.stringify(techniqueLoopbackWhere) }).then( res => {
+        const newTechniqueLoopbackWhere = JSON.parse(res.text);
+        console.log(" + where filter : ", newTechniqueLoopbackWhere);
+        return newTechniqueLoopbackWhere;
+      }).catch(e=> {
+        console.log("fail", e);
+      });
+
+
   }
 
 }

--- a/common/utils.js
+++ b/common/utils.js
@@ -1,6 +1,31 @@
 "use strict";
 
 const math = require("mathjs");
+//const panetOntology = require("./panet-service").PanetOntology;
+
+
+/**
+ * Expands the techniques where clause
+ * @param {object} filter
+ * @returns {object}
+ *//*
+exports.expandTechniques = async function (filter) {
+  if (filter && filter.include) {
+
+    filter.include = filter.include.map((i) => {
+      if (i.relation=="techniques" && i.scope && i.scope.where ) {
+        i.scope.where = await panetOntology.panet(i.scope.where);
+      }
+      else if ( i.scope && i.scope.include ) {
+        i.scope.include = i.scope.include.maps(expandTechniques);
+      }
+    })
+  }
+
+  return filter
+}*/
+
+
 
 /**
  * Get inclusions from filter
@@ -18,6 +43,7 @@ exports.getInclusions = (filter) =>
       ),
     )
     : {};
+
 
 /**
  * Get names of inclusions from filter


### PR DESCRIPTION
## Description

This PR solves the issue in the document search related to the "include" of datasets and techniques when integration with the techniques service was enabled. 

## Motivation

Previously for every document returned by the catalogue system, a call to the technique service was placed to expand the techniques.
We were able to move the technique expansion outside the document loop, reducing the number of requests to the technique service to only one.

## Fixes:

* None

## Changes:

* common/filter-mapper.js
* common/models/document.js
* common/panet-service.js
* common/utils.js

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
