### PR TITLE
added expansion on Panosc parameters to work on ranges

### DIFF
--- a/common/scicat-service.js
+++ b/common/scicat-service.js
@@ -13,7 +13,7 @@ exports.Dataset = class {
 
   async find(filter) {
     const jsonFilter = JSON.stringify(filter);
-    console.log(">>> Dataset.find filter", jsonFilter);
+    //console.log(">>> Dataset.find filter", jsonFilter);
     const url = jsonFilter
       ? baseUrl + "/Datasets?filter=" + jsonFilter
       : baseUrl + "/Datasets";
@@ -31,8 +31,8 @@ exports.Dataset = class {
   async findById(id, filter) {
     const encodedId = encodeURIComponent(id);
     const jsonFilter = JSON.stringify(filter);
-    console.log(">>> Dataset.findById pid", encodedId);
-    console.log(">>> Dataset.findById filter", jsonFilter);
+    //console.log(">>> Dataset.findById pid", encodedId);
+    //console.log(">>> Dataset.findById filter", jsonFilter);
     const url = jsonFilter
       ? baseUrl + "/Datasets/" + encodedId + "?filter=" + jsonFilter
       : baseUrl + "/Datasets/" + encodedId;
@@ -48,7 +48,7 @@ exports.Dataset = class {
 
   async count(filter) {
     const jsonFilter = JSON.stringify(filter);
-    console.log(">>> Dataset.count filter", jsonFilter);
+    //console.log(">>> Dataset.count filter", jsonFilter);
     const url = jsonFilter
       ? baseUrl + "/Datasets?filter=" + jsonFilter
       : baseUrl + "/Datasets";
@@ -67,8 +67,8 @@ exports.Dataset = class {
   async findByIdFiles(id, filter) {
     const encodedId = encodeURIComponent(id);
     const jsonFilter = JSON.stringify(filter);
-    console.log(">>> Dataset.findByIdFiles pid", encodedId);
-    console.log(">>> Dataset.findByIdFiles filter", jsonFilter);
+    //console.log(">>> Dataset.findByIdFiles pid", encodedId);
+    //console.log(">>> Dataset.findByIdFiles filter", jsonFilter);
     const url = jsonFilter
       ? baseUrl + "/Datasets/" + encodedId + "?filter=" + jsonFilter
       : baseUrl + "/Datasets/" + encodedId;
@@ -86,7 +86,7 @@ exports.PublishedData = class {
 
   async find(filter) {
     const jsonFilter = JSON.stringify(filter);
-    console.log(">>> PublishedData.find filter", jsonFilter);
+    //console.log(">>> PublishedData.find filter", jsonFilter);
     const url = jsonFilter
       ? baseUrl + "/PublishedData?filter=" + jsonFilter
       : baseUrl + "/PublishedData";
@@ -104,8 +104,8 @@ exports.PublishedData = class {
   async findById(id, filter) {
     const encodedId = encodeURIComponent(id);
     const jsonFilter = JSON.stringify(filter);
-    console.log(">>> PublishedData.findById pid", encodedId);
-    console.log(">>> PublishedData.findById filter", jsonFilter);
+    //console.log(">>> PublishedData.findById pid", encodedId);
+    //console.log(">>> PublishedData.findById filter", jsonFilter);
     const url = jsonFilter
       ? baseUrl + "/PublishedData/" + encodedId + "?filter=" + jsonFilter
       : baseUrl + "/PublishedData/" + encodedId;
@@ -121,7 +121,7 @@ exports.PublishedData = class {
 
   async count(where) {
     const jsonWhere = JSON.stringify(where);
-    console.log(">>> PublishedData.count where", jsonWhere);
+    //console.log(">>> PublishedData.count where", jsonWhere);
     const url = jsonWhere
       ? baseUrl + "/PublishedData/count?where=" + jsonWhere
       : baseUrl + "/PublishedData/count";
@@ -139,7 +139,7 @@ exports.Instrument = class {
 
   async find(filter) {
     const jsonFilter = JSON.stringify(filter);
-    console.log(">>> Instrument.find filter", jsonFilter);
+    //console.log(">>> Instrument.find filter", jsonFilter);
     const url = jsonFilter
       ? baseUrl + "/Instruments?filter=" + jsonFilter
       : baseUrl + "/Instruments";
@@ -157,8 +157,8 @@ exports.Instrument = class {
   async findById(id, filter) {
     const encodedId = encodeURIComponent(id);
     const jsonFilter = JSON.stringify(filter);
-    console.log(">>> Instrument.findById id", encodedId);
-    console.log(">>> Instrument.findById filter", jsonFilter);
+    //console.log(">>> Instrument.findById id", encodedId);
+    //console.log(">>> Instrument.findById filter", jsonFilter);
     const url = jsonFilter
       ? baseUrl + "/Instruments/" + encodedId + "?filter=" + jsonFilter
       : baseUrl + "/Instruments/" + encodedId;
@@ -174,7 +174,7 @@ exports.Instrument = class {
 
   async count(where) {
     const jsonWhere = JSON.stringify(where);
-    console.log(">>> Instrument.count where", jsonWhere);
+    //console.log(">>> Instrument.count where", jsonWhere);
     const url = jsonWhere
       ? baseUrl + "/Instruments/count?where=" + jsonWhere
       : baseUrl + "/Instruments/count";
@@ -192,7 +192,7 @@ exports.Sample = class {
 
   async find(filter) {
     const jsonFilter = JSON.stringify(filter);
-    console.log(">>> Sample.find filter", jsonFilter);
+    //console.log(">>> Sample.find filter", jsonFilter);
     const url = jsonFilter
       ? baseUrl + "/Samples?filter=" + jsonFilter
       : baseUrl + "/Samples";

--- a/common/utils.js
+++ b/common/utils.js
@@ -136,6 +136,19 @@ exports.filterOnSecondary = (result, primary, secondary) =>
   );
 
 /**
+ *
+ * @param {string} unit unit to be checked
+ * @returns the same unit or the construct to check for the unit full name or abbreviation
+ */
+exports.includeUnitFullName = (unit) => {
+  let output = unit;
+  if (unit == "K") {
+    output = { "inq" : ["K","kelvin"] };
+  }
+  return output;
+};
+
+/**
  * Convert a quantity to SI units
  * @param {number} value Value to be converted
  * @param {string} unit Unit to be converted


### PR DESCRIPTION
added expansion on Panosc parameters to work on ranges. Parameters supported: sample_temperature and incident_wavelength

## Description
Some in our datasets we do not have a single value for sample temperature or incident wavelength, but a range with min and max.
The query specified in PaNOSC catches only datasets with a single value. This PR expands the query on the parameters indicated above to cover the datasets where there is a min and max value, aka an interval

## Motivation
It is our intention to return datasets where the parameter requested is specified as finite interval

## Fixes:
* filter-mapping.js
* utils.js
* scicat-service.js

## Changes:

## Tests included/Docs Updated?

- [ x ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
