### PR TITLE
Swap 2724 2

### DIFF
--- a/common/filter-mapper.js
+++ b/common/filter-mapper.js
@@ -529,59 +529,6 @@ const mapWhereFilter = (where, model) => {
         scicatWhere.and = [];
         if (value !== null) {
           scicatWhere = mapWhereFilterParameter(name,value,unit);
-          // if (unit) {
-          //   if (isNaN(value)) {
-          //     const extractedValue = Object.values(value).pop();
-          //     if (Array.isArray(extractedValue)) {
-          //       const arrayValues = extractedValue.map((value) =>
-          //         utils.convertToSI(value, unit)
-          //       );
-          //       const formattedValueSI = Object.assign(
-          //         ...Object.keys(value).map((key) => ({
-          //           [key]: arrayValues.map((item) => item.valueSI),
-          //         }))
-          //       );
-          //       scicatWhere.and.push({
-          //         [`scientificMetadata.${name}.valueSI`]: formattedValueSI,
-          //       });
-          //       const unitSI = arrayValues.pop().unitSI;
-          //       scicatWhere.and.push({
-          //         [`scientificMetadata.${name}.unitSI`]: utils.includeUnitFullName(unitSI),
-          //       });
-          //     } else {
-          //       const { valueSI, unitSI } = utils.convertToSI(
-          //         extractedValue,
-          //         unit
-          //       );
-          //       const formattedValueSI = Object.assign(
-          //         ...Object.keys(value).map((key) => ({ [key]: valueSI }))
-          //       );
-          //       scicatWhere.and.push({
-          //         [`scientificMetadata.${name}.valueSI`]: formattedValueSI,
-          //       });
-          //       scicatWhere.and.push({
-          //         [`scientificMetadata.${name}.unitSI`]: utils.includeUnitFullName(unitSI),
-          //       });
-          //     }
-          //   } else {
-          //     const { valueSI, unitSI } = utils.convertToSI(value, unit);
-          //     scicatWhere.and.push({
-          //       [`scientificMetadata.${name}.valueSI`]: valueSI,
-          //     });
-          //     scicatWhere.and.push({
-          //       [`scientificMetadata.${name}.unitSI`]: utils.includeUnitFullName(unitSI),
-          //     });
-          //   }
-          // } else {
-          //   scicatWhere.and.push({
-          //     "or": [{
-          //       [`scientificMetadata.${name}.value`]: value
-          //     },
-          //     {
-          //       [`scientificMetadata.${name}.v`]: value
-          //     }]
-          //   });
-          // }
         } else {
           const err = new Error();
           err.name = "FilterError";
@@ -602,63 +549,8 @@ const mapWhereFilter = (where, model) => {
       );
       const scientificMetadata = parameters.map(({ name, value, unit }) => {
         if (name) {
-          let filter = { and: [] };
           if (value !== null) {
-            filter = mapWhereFilterParameter(name,value,unit);
-            // if (unit) {
-            //   if (isNaN(value)) {
-            //     const extractedValue = Object.values(value).pop();
-            //     if (Array.isArray(extractedValue)) {
-            //       const arrayValues = extractedValue.map((value) =>
-            //         utils.convertToSI(value, unit)
-            //       );
-            //       const formattedValueSI = Object.assign(
-            //         ...Object.keys(value).map((key) => ({
-            //           [key]: arrayValues.map((item) => item.valueSI),
-            //         }))
-            //       );
-            //       filter.and.push({
-            //         [`scientificMetadata.${name}.valueSI`]: formattedValueSI,
-            //       });
-            //       const unitSI = arrayValues.pop().unitSI;
-            //       filter.and.push({
-            //         [`scientificMetadata.${name}.unitSI`]: utils.includeUnitFullName(unitSI),
-            //       });
-            //     } else {
-            //       const { valueSI, unitSI } = utils.convertToSI(
-            //         extractedValue,
-            //         unit
-            //       );
-            //       const formattedValueSI = Object.assign(
-            //         ...Object.keys(value).map((key) => ({ [key]: valueSI }))
-            //       );
-            //       filter.and.push({
-            //         [`scientificMetadata.${name}.valueSI`]: formattedValueSI,
-            //       });
-            //       filter.and.push({
-            //         [`scientificMetadata.${name}.unitSI`]: utils.includeUnitFullName(unitSI),
-            //       });
-            //     }
-            //   } else {
-            //     const { valueSI, unitSI } = utils.convertToSI(value, unit);
-            //     filter.and.push({
-            //       [`scientificMetadata.${name}.valueSI`]: valueSI,
-            //     });
-            //     filter.and.push({
-            //       [`scientificMetadata.${name}.unitSI`]: utils.includeUnitFullName(unitSI),
-            //     });
-            //   }
-            // } else {
-            //   filter.and.push({
-            //     "or": [{
-            //       [`scientificMetadata.${name}.value`]: value
-            //     },
-            //     {
-            //       [`scientificMetadata.${name}.v`]: value
-            //     }]
-            //   });
-            // }
-            return filter;
+            return mapWhereFilterParameter(name,value,unit);
           } else {
             const err = new Error();
             err.name = "FilterError";

--- a/common/response-mapper.js
+++ b/common/response-mapper.js
@@ -113,6 +113,7 @@ exports.document = async (scicatPublishedData, filter, scores = {}) => {
   };
 
   const inclusions = utils.getInclusions(filter);
+  //console.log("Response Mapper Document: doi " + scicatPublishedData.doi);
 
   if (Object.keys(inclusions).includes("datasets")) {
     const scicatFilter = await filterMapper.dataset(inclusions.datasets);
@@ -144,6 +145,10 @@ exports.document = async (scicatPublishedData, filter, scores = {}) => {
           filter.include = scicatFilter.include;
         }
         const datasets = await scicatDatasetService.find(filter);
+        // if ( pid == "20.500.12269/2511nicos_00002511.hdf" ) {
+        //   console.log(" - query : " + JSON.stringify(filter));
+        //   console.log(" - Found " + datasets.length + " datasets");
+        // }
         return datasets.length > 0 ? datasets[0] : {};
       })
     );

--- a/common/utils.js
+++ b/common/utils.js
@@ -3,6 +3,10 @@
 const math = require("mathjs");
 //const panetOntology = require("./panet-service").PanetOntology;
 
+const unitFullNames = {
+  "K" : ["K", "kelvin"],
+  "m" : ["m", "meter"]
+};
 
 /**
  * Expands the techniques where clause
@@ -142,8 +146,8 @@ exports.filterOnSecondary = (result, primary, secondary) =>
  */
 exports.includeUnitFullName = (unit) => {
   let output = unit;
-  if (unit == "K") {
-    output = { "inq" : ["K","kelvin"] };
+  if ( Object.keys(unitFullNames).includes(unit)) {
+    output = { "inq" : unitFullNames[unit] };
   }
   return output;
 };


### PR DESCRIPTION
## Description
Fixing units conversion between PaNOSC requests and SciCat.

## Motivation
I'm working on the writing few queries to be used as example for PaNOSC. I keep finding many issues converting units between the two systems.
I will make this query working and than I will make sure that both in scicat and PaNOSC data portal, we use the official naming convention of units

## Fixes:
* response-mapping.js

## Changes:
n/a

## Tests included/Docs Updated?

- [ x] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
