### PR TITLE
Add filter fields to exclude documents thumbnails

### DIFF
--- a/common/filter-mapper.js
+++ b/common/filter-mapper.js
@@ -118,7 +118,7 @@ exports.dataset = async (filter) => {
 
 exports.document = (filter) => {
   if (!filter) {
-    return null;
+    return { fields: { thumbnail: false } };
   } else {
     let scicatFilter = {};
     if (filter.where) {
@@ -165,6 +165,11 @@ exports.document = (filter) => {
     }
     if (filter.limit) {
       scicatFilter.limit = filter.limit;
+    }
+    if (filter.fields) {
+      scicatFilter.fields.thumbnail = false;
+    } else {
+      scicatFilter.fields = { thumbnail: false };
     }
     return scicatFilter;
   }

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -26,7 +26,7 @@ describe("Document", () => {
   describe("GET /documents", () => {
     context("without filter", () => {
       it("should return an array of documents", (done) => {
-        sandbox
+        const findStub = sandbox
           .stub(ScicatPubDataService.prototype, "find")
           .resolves(mockStubs.publishedData.find.noFilter);
 
@@ -45,7 +45,9 @@ describe("Document", () => {
               expect(document).to.have.property("type");
               expect(document).to.have.property("title");
               expect(document).to.have.property("score");
+              expect(document).not.to.have.property("thumbnail");
             });
+            expect(findStub.args[0][0]).to.be.eql({ fields:{ thumbnail: false } });
             done();
           });
       });
@@ -53,7 +55,7 @@ describe("Document", () => {
 
     context("where type is publication and person is James Chadwick", () => {
       it("should return an array of documents matching the type and the person", (done) => {
-        sandbox
+        const findStub = sandbox
           .stub(ScicatPubDataService.prototype, "find")
           .resolves(mockStubs.publishedData.find.personFilter);
         const callback = sandbox.stub(ScicatDatasetService.prototype, "find");
@@ -104,9 +106,19 @@ describe("Document", () => {
               expect(document.datasets).to.be.an("array").and.not.empty;
               expect(document).to.have.property("members");
               expect(document.members).to.be.an("array").and.not.empty;
+              expect(document).not.to.have.property("thumbnail");
               document.members.forEach((member) => {
                 expect(member.person.fullName).to.equal("James Chadwick");
               });
+            });
+            expect(findStub.args[0][0]).to.be.eql({
+              where: {
+                or: [
+                  { creator: "James Chadwick" },
+                  { authors:"James Chadwick" }
+                ]
+              },
+              fields: { thumbnail: false }
             });
             done();
           });
@@ -390,7 +402,7 @@ describe("Document", () => {
 
   describe("GET /documents/{id}", () => {
     it("should return the document with the requested pid", (done) => {
-      sandbox
+      const findByIdStub = sandbox
         .stub(ScicatPubDataService.prototype, "findById")
         .resolves(mockStubs.publishedData.findById);
 
@@ -408,6 +420,9 @@ describe("Document", () => {
           expect(res.body).to.have.property("isPublic");
           expect(res.body).to.have.property("type");
           expect(res.body).to.have.property("title");
+          expect(findByIdStub.args[0][1]).to.be.eql(
+            { fields: { thumbnail: false } }
+          );
           done();
         });
     });


### PR DESCRIPTION
## Description

Add filter fields to exclude documents thumbnails

## Motivation

Returning the thumbnail for each document, which is later discarded, has an impact on the GET performances as data in this field is usually big

## Changes:

* filter fields to exclude thumbnail

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
