### PR TITLE
Backend next compat

### DIFF
--- a/common/scicat-service.js
+++ b/common/scicat-service.js
@@ -13,10 +13,10 @@ exports.Dataset = class {
 
   async find(filter) {
     const jsonFilter = JSON.stringify(filter);
-    //console.log(">>> Dataset.find filter", jsonFilter);
+    console.log(">>> Dataset.find filter", jsonFilter);
     const url = jsonFilter
-      ? baseUrl + "/Datasets?filter=" + jsonFilter
-      : baseUrl + "/Datasets";
+      ? baseUrl + "/datasets?filter=" + jsonFilter
+      : baseUrl + "/datasets";
     const res = await superagent.get(url);
     return JSON.parse(res.text);
   }
@@ -34,8 +34,8 @@ exports.Dataset = class {
     //console.log(">>> Dataset.findById pid", encodedId);
     //console.log(">>> Dataset.findById filter", jsonFilter);
     const url = jsonFilter
-      ? baseUrl + "/Datasets/" + encodedId + "?filter=" + jsonFilter
-      : baseUrl + "/Datasets/" + encodedId;
+      ? baseUrl + "/datasets/" + encodedId + "?filter=" + jsonFilter
+      : baseUrl + "/datasets/" + encodedId;
     const res = await superagent.get(url);
     return JSON.parse(res.text);
   }
@@ -50,8 +50,8 @@ exports.Dataset = class {
     const jsonFilter = JSON.stringify(filter);
     //console.log(">>> Dataset.count filter", jsonFilter);
     const url = jsonFilter
-      ? baseUrl + "/Datasets?filter=" + jsonFilter
-      : baseUrl + "/Datasets";
+      ? baseUrl + "/datasets?filter=" + jsonFilter
+      : baseUrl + "/datasets";
     const res = await superagent.get(url);
     const datasets = JSON.parse(res.text);
     return { count: datasets.length };
@@ -85,14 +85,14 @@ exports.PublishedData = class {
    */
 
   async find(filter) {
-    console.log("PublishedData.find - BEGIN");
+    console.log("publisheddata.find - BEGIN");
     const jsonFilter = JSON.stringify(filter);
-    console.log("PublishedData.find filter", jsonFilter);
+    console.log("publisheddata.find filter", jsonFilter);
     const url = jsonFilter
-      ? baseUrl + "/PublishedData?filter=" + jsonFilter
-      : baseUrl + "/PublishedData";
+      ? baseUrl + "/publisheddata?filter=" + jsonFilter
+      : baseUrl + "/publisheddata";
     const res = await superagent.get(url);
-    console.log("PublishedData.find - END");
+    console.log("publisheddata.find - END");
     return JSON.parse(res.text);
   }
 
@@ -106,11 +106,11 @@ exports.PublishedData = class {
   async findById(id, filter) {
     const encodedId = encodeURIComponent(id);
     const jsonFilter = JSON.stringify(filter);
-    //console.log(">>> PublishedData.findById pid", encodedId);
-    //console.log(">>> PublishedData.findById filter", jsonFilter);
+    //console.log(">>> publisheddata.findById pid", encodedId);
+    //console.log(">>> publisheddata.findById filter", jsonFilter);
     const url = jsonFilter
-      ? baseUrl + "/PublishedData/" + encodedId + "?filter=" + jsonFilter
-      : baseUrl + "/PublishedData/" + encodedId;
+      ? baseUrl + "/publisheddata/" + encodedId + "?filter=" + jsonFilter
+      : baseUrl + "/publisheddata/" + encodedId;
     const res = await superagent.get(url);
     return JSON.parse(res.text);
   }
@@ -123,10 +123,10 @@ exports.PublishedData = class {
 
   async count(where) {
     const jsonWhere = JSON.stringify(where);
-    //console.log(">>> PublishedData.count where", jsonWhere);
+    //console.log(">>> publisheddata.count where", jsonWhere);
     const url = jsonWhere
-      ? baseUrl + "/PublishedData/count?where=" + jsonWhere
-      : baseUrl + "/PublishedData/count";
+      ? baseUrl + "/publisheddata/count?where=" + jsonWhere
+      : baseUrl + "/publisheddata/count";
     const res = await superagent.get(url);
     return JSON.parse(res.text);
   }
@@ -143,8 +143,8 @@ exports.Instrument = class {
     const jsonFilter = JSON.stringify(filter);
     //console.log(">>> Instrument.find filter", jsonFilter);
     const url = jsonFilter
-      ? baseUrl + "/Instruments?filter=" + jsonFilter
-      : baseUrl + "/Instruments";
+      ? baseUrl + "/instruments?filter=" + jsonFilter
+      : baseUrl + "/instruments";
     const res = await superagent.get(url);
     return JSON.parse(res.text);
   }
@@ -162,8 +162,8 @@ exports.Instrument = class {
     //console.log(">>> Instrument.findById id", encodedId);
     //console.log(">>> Instrument.findById filter", jsonFilter);
     const url = jsonFilter
-      ? baseUrl + "/Instruments/" + encodedId + "?filter=" + jsonFilter
-      : baseUrl + "/Instruments/" + encodedId;
+      ? baseUrl + "/instruments/" + encodedId + "?filter=" + jsonFilter
+      : baseUrl + "/instruments/" + encodedId;
     const res = await superagent.get(url);
     return JSON.parse(res.text);
   }
@@ -178,8 +178,8 @@ exports.Instrument = class {
     const jsonWhere = JSON.stringify(where);
     //console.log(">>> Instrument.count where", jsonWhere);
     const url = jsonWhere
-      ? baseUrl + "/Instruments/count?where=" + jsonWhere
-      : baseUrl + "/Instruments/count";
+      ? baseUrl + "/instruments/count?where=" + jsonWhere
+      : baseUrl + "/instruments/count";
     const res = await superagent.get(url);
     return JSON.parse(res.text);
   }
@@ -196,8 +196,8 @@ exports.Sample = class {
     const jsonFilter = JSON.stringify(filter);
     //console.log(">>> Sample.find filter", jsonFilter);
     const url = jsonFilter
-      ? baseUrl + "/Samples?filter=" + jsonFilter
-      : baseUrl + "/Samples";
+      ? baseUrl + "/samples?filter=" + jsonFilter
+      : baseUrl + "/samples";
     const res = await superagent.get(url);
     return JSON.parse(res.text);
   }

--- a/common/scicat-service.js
+++ b/common/scicat-service.js
@@ -12,11 +12,10 @@ exports.Dataset = class {
    */
 
   async find(filter) {
-    const jsonFilter = JSON.stringify(filter);
-    console.log(">>> Dataset.find filter", jsonFilter);
-    const url = jsonFilter
-      ? baseUrl + "/datasets?filter=" + jsonFilter
-      : baseUrl + "/datasets";
+
+    const jsonFilter = JSON.stringify(filter ? filter : {});
+    //  console.log(">>> Dataset.find filter", jsonFilter);
+    const url = baseUrl + "/datasets?filter=" + jsonFilter;
     const res = await superagent.get(url);
     return JSON.parse(res.text);
   }
@@ -70,10 +69,10 @@ exports.Dataset = class {
     //console.log(">>> Dataset.findByIdFiles pid", encodedId);
     //console.log(">>> Dataset.findByIdFiles filter", jsonFilter);
     const url = jsonFilter
-      ? baseUrl + "/Datasets/" + encodedId + "?filter=" + jsonFilter
-      : baseUrl + "/Datasets/" + encodedId;
+      ? baseUrl + "/datasets/" + encodedId + "/origdatablocks?filter=" + jsonFilter
+      : baseUrl + "/datasets/" + encodedId + "/origdatablocks";
     const res = await superagent.get(url);
-    return JSON.parse(res.text)["origdatablocks"];
+    return JSON.parse(res.text);
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "mathjs": "^7.6.0",
         "serve-favicon": "^2.5.0",
         "strong-error-handler": "^3.5.0",
-        "superagent": "^5.3.1"
+        "superagent": "^7.1.5"
       },
       "devDependencies": {
         "chai": "^4.2.0",
@@ -321,6 +321,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "node_modules/asn1": {
       "version": "0.2.4",
@@ -974,6 +979,15 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -1543,9 +1557,9 @@
       "dev": true
     },
     "node_modules/fast-safe-stringify": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/feature-policy": {
       "version": "0.3.0",
@@ -1718,6 +1732,7 @@
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
       "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
       "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
+      "dev": true,
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
@@ -1982,6 +1997,14 @@
       },
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/hide-powered-by": {
@@ -4773,40 +4796,46 @@
       }
     },
     "node_modules/superagent": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.3.1.tgz",
-      "integrity": "sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==",
-      "deprecated": "Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.5.tgz",
+      "integrity": "sha512-HQYyGuDRFGmZ6GNC4hq2f37KnsY9Lr0/R1marNZTgMweVDQLTLJJ6DGQ9Tj/xVVs5HEnop9EMmTbywb5P30aqw==",
       "dependencies": {
         "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.2",
-        "debug": "^4.1.1",
-        "fast-safe-stringify": "^2.0.7",
-        "form-data": "^3.0.0",
-        "formidable": "^1.2.2",
+        "cookiejar": "^2.1.3",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.0.1",
         "methods": "^1.1.2",
-        "mime": "^2.4.6",
-        "qs": "^6.9.4",
+        "mime": "^2.5.0",
+        "qs": "^6.10.3",
         "readable-stream": "^3.6.0",
-        "semver": "^7.3.2"
+        "semver": "^7.3.7"
       },
       "engines": {
-        "node": ">= 7.0.0"
+        "node": ">=6.4.0 <13 || >=14"
       }
     },
     "node_modules/superagent/node_modules/debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/superagent/node_modules/form-data": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -4816,10 +4845,24 @@
         "node": ">= 6"
       }
     },
+    "node_modules/superagent/node_modules/formidable": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
+      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+      "dependencies": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
     "node_modules/superagent/node_modules/mime": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "bin": {
         "mime": "cli.js"
       },
@@ -5684,6 +5727,11 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -6194,6 +6242,15 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
     },
+    "dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -6635,9 +6692,9 @@
       "dev": true
     },
     "fast-safe-stringify": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "feature-policy": {
       "version": "0.3.0",
@@ -6770,7 +6827,8 @@
     "formidable": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
-      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
+      "dev": true
     },
     "forwarded": {
       "version": "0.2.0",
@@ -6959,6 +7017,11 @@
         "content-security-policy-builder": "2.1.0",
         "dasherize": "2.0.0"
       }
+    },
+    "hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g=="
     },
     "hide-powered-by": {
       "version": "1.1.0",
@@ -9158,45 +9221,56 @@
       }
     },
     "superagent": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.3.1.tgz",
-      "integrity": "sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.5.tgz",
+      "integrity": "sha512-HQYyGuDRFGmZ6GNC4hq2f37KnsY9Lr0/R1marNZTgMweVDQLTLJJ6DGQ9Tj/xVVs5HEnop9EMmTbywb5P30aqw==",
       "requires": {
         "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.2",
-        "debug": "^4.1.1",
-        "fast-safe-stringify": "^2.0.7",
-        "form-data": "^3.0.0",
-        "formidable": "^1.2.2",
+        "cookiejar": "^2.1.3",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.0.1",
         "methods": "^1.1.2",
-        "mime": "^2.4.6",
-        "qs": "^6.9.4",
+        "mime": "^2.5.0",
+        "qs": "^6.10.3",
         "readable-stream": "^3.6.0",
-        "semver": "^7.3.2"
+        "semver": "^7.3.7"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "form-data": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
             "mime-types": "^2.1.12"
           }
         },
+        "formidable": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
+          "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+          "requires": {
+            "dezalgo": "^1.0.4",
+            "hexoid": "^1.0.0",
+            "once": "^1.4.0",
+            "qs": "^6.11.0"
+          }
+        },
         "mime": {
-          "version": "2.4.6",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
         },
         "ms": {
           "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -848,9 +848,9 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "node_modules/cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -1227,9 +1227,9 @@
       }
     },
     "node_modules/eslint/node_modules/cross-spawn/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -1268,9 +1268,9 @@
       }
     },
     "node_modules/eslint/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -2048,7 +2048,7 @@
     "node_modules/httpntlm": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.6.1.tgz",
-      "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
+      "integrity": "sha512-Tcz3Ct9efvNqw3QdTl3h6IgRRlIQxwKkJELN/aAIGnzi2xvb3pDHdnMs8BrxWLV6OoT4DlVyhzSVhFt/tk0lIw==",
       "dependencies": {
         "httpreq": ">=0.4.22",
         "underscore": "~1.7.0"
@@ -3041,6 +3041,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -3490,7 +3501,7 @@
     "node_modules/nodemailer-direct-transport": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/nodemailer-direct-transport/-/nodemailer-direct-transport-3.3.2.tgz",
-      "integrity": "sha1-6W+vuQNYVglH5WkBfZfmBzilCoY=",
+      "integrity": "sha512-vEMLWdUZP9NpbeabM8VTiB3Ar1R0ixASp/6DdKX372LK4USKB4Lq12/WCp69k/+kWk4RiCWWEGo57CcsXOs/bw==",
       "dependencies": {
         "nodemailer-shared": "1.1.0",
         "smtp-connection": "2.12.0"
@@ -4059,9 +4070,9 @@
       "integrity": "sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ="
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -4267,7 +4278,7 @@
     "node_modules/smtp-connection": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.0.tgz",
-      "integrity": "sha1-1275EnyyPCJZ7bHoNJwujV4tdME=",
+      "integrity": "sha512-UP5jK4s5SGcUcqPN4U9ingqKt9mXYSKa52YhqxPuMecAnUOsVJpOmtgGaOm1urUBJZlzDt1M9WhZZkgbhxQlvg==",
       "dependencies": {
         "httpntlm": "1.6.1",
         "nodemailer-shared": "1.1.0"
@@ -4835,9 +4846,12 @@
       }
     },
     "node_modules/superagent/node_modules/semver": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4911,7 +4925,7 @@
     "node_modules/swagger-ui": {
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-2.2.10.tgz",
-      "integrity": "sha1-sl56IWZOXZC/OR2zDbCN5B6FLXs=",
+      "integrity": "sha512-dXSMq5umiy6XJNhpiYBYOsjMvq3+qoISWL55cMtOeoNqv/gA6NQ19F+4gJWQ81PL4V/j/F6V6tA5aSlCIV3PKg==",
       "deprecated": "No longer maintained, please upgrade to swagger-ui@3."
     },
     "node_modules/table": {
@@ -5113,7 +5127,7 @@
     "node_modules/underscore": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+      "integrity": "sha512-cp0oQQyZhUM1kpJDLdGO1jPZHgS/MpzoWYfe9+CM2h/QGDZlqwT2T3YGukuBdaNJ/CAPoeyAZRRHz8JFo176vA=="
     },
     "node_modules/underscore.string": {
       "version": "3.3.5",
@@ -5207,9 +5221,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5349,6 +5363,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yamljs": {
       "version": "0.3.0",
@@ -6080,9 +6099,9 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -6336,9 +6355,9 @@
           },
           "dependencies": {
             "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "version": "5.7.2",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+              "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
               "dev": true
             }
           }
@@ -6365,9 +6384,9 @@
           "dev": true
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         },
         "shebang-command": {
@@ -6989,7 +7008,7 @@
     "httpntlm": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.6.1.tgz",
-      "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
+      "integrity": "sha512-Tcz3Ct9efvNqw3QdTl3h6IgRRlIQxwKkJELN/aAIGnzi2xvb3pDHdnMs8BrxWLV6OoT4DlVyhzSVhFt/tk0lIw==",
       "requires": {
         "httpreq": ">=0.4.22",
         "underscore": "~1.7.0"
@@ -7774,6 +7793,14 @@
         }
       }
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -8136,7 +8163,7 @@
     "nodemailer-direct-transport": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/nodemailer-direct-transport/-/nodemailer-direct-transport-3.3.2.tgz",
-      "integrity": "sha1-6W+vuQNYVglH5WkBfZfmBzilCoY=",
+      "integrity": "sha512-vEMLWdUZP9NpbeabM8VTiB3Ar1R0ixASp/6DdKX372LK4USKB4Lq12/WCp69k/+kWk4RiCWWEGo57CcsXOs/bw==",
       "requires": {
         "nodemailer-shared": "1.1.0",
         "smtp-connection": "2.12.0"
@@ -8564,9 +8591,9 @@
       "integrity": "sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ="
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
     },
     "send": {
       "version": "0.18.0",
@@ -8740,7 +8767,7 @@
     "smtp-connection": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.0.tgz",
-      "integrity": "sha1-1275EnyyPCJZ7bHoNJwujV4tdME=",
+      "integrity": "sha512-UP5jK4s5SGcUcqPN4U9ingqKt9mXYSKa52YhqxPuMecAnUOsVJpOmtgGaOm1urUBJZlzDt1M9WhZZkgbhxQlvg==",
       "requires": {
         "httpntlm": "1.6.1",
         "nodemailer-shared": "1.1.0"
@@ -9187,9 +9214,12 @@
           }
         },
         "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -9250,7 +9280,7 @@
     "swagger-ui": {
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-2.2.10.tgz",
-      "integrity": "sha1-sl56IWZOXZC/OR2zDbCN5B6FLXs="
+      "integrity": "sha512-dXSMq5umiy6XJNhpiYBYOsjMvq3+qoISWL55cMtOeoNqv/gA6NQ19F+4gJWQ81PL4V/j/F6V6tA5aSlCIV3PKg=="
     },
     "table": {
       "version": "5.4.6",
@@ -9414,7 +9444,7 @@
     "underscore": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+      "integrity": "sha512-cp0oQQyZhUM1kpJDLdGO1jPZHgS/MpzoWYfe9+CM2h/QGDZlqwT2T3YGukuBdaNJ/CAPoeyAZRRHz8JFo176vA=="
     },
     "underscore.string": {
       "version": "3.3.5",
@@ -9483,9 +9513,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "workerpool": {
@@ -9588,6 +9618,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yamljs": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mathjs": "^7.6.0",
     "serve-favicon": "^2.5.0",
     "strong-error-handler": "^3.5.0",
-    "superagent": "^5.3.1"
+    "superagent": "^7.1.5"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
## Description

Scicat backend next did some breaking api changes, so fix those. 

## Motivation


## Fixes:

* paths are lowercase
* origdatablocks need to be fetched from its own endpoint

## Changes:

* bump superagent

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
