### PR TITLE
use datasets count endpoint instead of datasets.length

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,29 +2,29 @@ name: Test
 
 on:
   pull_request:
-    branches: 
+    branches:
       - master
 jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
-    steps:  
+    steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        
+
       - name: Cache node_modules
         id: cache-node-modules
         uses: actions/cache@v3
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
-          
+
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Test
         run: |
-          export BASE_URL=https://scicat.ess.eu/api/v3
+          export BASE_URL=https://scicat.ess.eu
           npm run lint
           npm run test

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk update && apk upgrade
 # please change the following variable according to your deployment
 # the current values are set for ESS environment
 ARG NODE_ENV="production"
-ARG BASE_URL="https://scicat.ess.eu/api/v3"
+ARG BASE_URL="https://scicat.ess.eu"
 ARG FACILITY="ESS"
 ARG PSS_BASE_URL="http://scicat08.esss.lu.se:32222"
 ARG PSS_ENABLE=1

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 4. Set the ENV variables
    ```bash
-   export BASE_URL=<CATAMEL_API_BASE_URL>               # e.g. https://scicat.ess.eu/api/v3
+   export BASE_URL=<SCICAT_BACKEND_API_BASE_URL>        # e.g. https://scicat.ess.eu
    export FACILITY=<YOUR_FACILITY>                      # e.g. ESS
    export PSS_BASE_URL=<PANOSC_SEARCH_SCORING_API_URL>  # e.g. http://scicat08.esss.lu.se:32222
    export PSS_ENABLE=<1 or 0>                           # e.g. 1 if you have a PSS running in your facility or 0 if you do not
@@ -81,13 +81,13 @@ please refer to the related container repository accessible on github at the fol
 
   - https://github.com/SciCatProject/panosc-search-api/pkgs/container/panosc-search-api
 
-To install the latest stable releas of the PaNOSC Search API (SciCat implementation), 
+To install the latest stable releas of the PaNOSC Search API (SciCat implementation),
 you may run the following command in a terminal:
 ```bash
    docker pull ghcr.io/scicatproject/panosc-search-api:stable
 ```
 
-If you want to deploy a specific version, replace _stable_ with the version tag. 
+If you want to deploy a specific version, replace _stable_ with the version tag.
 If you weant to install verion 1.1.2, the command should be:
 ```bash
    docker pull ghcr.io/scicatproject/panosc-search-api:v1.1.2

--- a/common/scicat-service.js
+++ b/common/scicat-service.js
@@ -2,7 +2,7 @@
 
 const superagent = require("superagent");
 
-const baseUrl = process.env.BASE_URL || "http://localhost:3030/api/v3";
+const baseUrl = process.env.BASE_URL || "http://localhost:3030";
 
 exports.Dataset = class {
   /**
@@ -15,7 +15,7 @@ exports.Dataset = class {
 
     const jsonFilter = JSON.stringify(filter ? filter : {});
     //  console.log(">>> Dataset.find filter", jsonFilter);
-    const url = baseUrl + "/datasets?filter=" + jsonFilter;
+    const url = baseUrl + "/api/v4/datasets/public?filter=" + jsonFilter;
     const res = await superagent.get(url);
     return JSON.parse(res.text);
   }
@@ -33,8 +33,8 @@ exports.Dataset = class {
     //console.log(">>> Dataset.findById pid", encodedId);
     //console.log(">>> Dataset.findById filter", jsonFilter);
     const url = jsonFilter
-      ? baseUrl + "/datasets/" + encodedId + "?filter=" + jsonFilter
-      : baseUrl + "/datasets/" + encodedId;
+      ? baseUrl + "/api/v4/datasets/public" + encodedId + "?filter=" + jsonFilter
+      : baseUrl + "/api/v4/datasets/public" + encodedId;
     const res = await superagent.get(url);
     return JSON.parse(res.text);
   }
@@ -47,13 +47,11 @@ exports.Dataset = class {
 
   async count(filter) {
     const jsonFilter = JSON.stringify(filter);
-    //console.log(">>> Dataset.count filter", jsonFilter);
     const url = jsonFilter
-      ? baseUrl + "/datasets?filter=" + jsonFilter
-      : baseUrl + "/datasets";
+      ? baseUrl + "/api/v4/datasets/public/count?filter=" + jsonFilter
+      : baseUrl + "/api/v4/datasets/public/count";
     const res = await superagent.get(url);
-    const datasets = JSON.parse(res.text);
-    return { count: datasets.length };
+    return JSON.parse(res.text);
   }
 
   /**
@@ -69,8 +67,8 @@ exports.Dataset = class {
     //console.log(">>> Dataset.findByIdFiles pid", encodedId);
     //console.log(">>> Dataset.findByIdFiles filter", jsonFilter);
     const url = jsonFilter
-      ? baseUrl + "/datasets/" + encodedId + "/origdatablocks?filter=" + jsonFilter
-      : baseUrl + "/datasets/" + encodedId + "/origdatablocks";
+      ? baseUrl + "/api/v3/datasets/" + encodedId + "/origdatablocks?filter=" + jsonFilter
+      : baseUrl + "/api/v3/datasets/" + encodedId + "/origdatablocks";
     const res = await superagent.get(url);
     return JSON.parse(res.text);
   }
@@ -88,8 +86,8 @@ exports.PublishedData = class {
     const jsonFilter = JSON.stringify(filter);
     console.log("publisheddata.find filter", jsonFilter);
     const url = jsonFilter
-      ? baseUrl + "/publisheddata?filter=" + jsonFilter
-      : baseUrl + "/publisheddata";
+      ? baseUrl + "/api/v3/publisheddata?filter=" + jsonFilter
+      : baseUrl + "/api/v3/publisheddata";
     const res = await superagent.get(url);
     console.log("publisheddata.find - END");
     return JSON.parse(res.text);
@@ -108,8 +106,8 @@ exports.PublishedData = class {
     //console.log(">>> publisheddata.findById pid", encodedId);
     //console.log(">>> publisheddata.findById filter", jsonFilter);
     const url = jsonFilter
-      ? baseUrl + "/publisheddata/" + encodedId + "?filter=" + jsonFilter
-      : baseUrl + "/publisheddata/" + encodedId;
+      ? baseUrl + "/api/v3/publisheddata/" + encodedId + "?filter=" + jsonFilter
+      : baseUrl + "/api/v3/publisheddata/" + encodedId;
     const res = await superagent.get(url);
     return JSON.parse(res.text);
   }
@@ -124,8 +122,8 @@ exports.PublishedData = class {
     const jsonWhere = JSON.stringify(where);
     //console.log(">>> publisheddata.count where", jsonWhere);
     const url = jsonWhere
-      ? baseUrl + "/publisheddata/count?where=" + jsonWhere
-      : baseUrl + "/publisheddata/count";
+      ? baseUrl + "/api/v3/publisheddata/count?where=" + jsonWhere
+      : baseUrl + "/api/v3/publisheddata/count";
     const res = await superagent.get(url);
     return JSON.parse(res.text);
   }
@@ -142,8 +140,8 @@ exports.Instrument = class {
     const jsonFilter = JSON.stringify(filter);
     //console.log(">>> Instrument.find filter", jsonFilter);
     const url = jsonFilter
-      ? baseUrl + "/instruments?filter=" + jsonFilter
-      : baseUrl + "/instruments";
+      ? baseUrl + "/api/v3/instruments?filter=" + jsonFilter
+      : baseUrl + "/api/v3/instruments";
     const res = await superagent.get(url);
     return JSON.parse(res.text);
   }
@@ -161,8 +159,8 @@ exports.Instrument = class {
     //console.log(">>> Instrument.findById id", encodedId);
     //console.log(">>> Instrument.findById filter", jsonFilter);
     const url = jsonFilter
-      ? baseUrl + "/instruments/" + encodedId + "?filter=" + jsonFilter
-      : baseUrl + "/instruments/" + encodedId;
+      ? baseUrl + "/api/v3/instruments/" + encodedId + "?filter=" + jsonFilter
+      : baseUrl + "/api/v3/instruments/" + encodedId;
     const res = await superagent.get(url);
     return JSON.parse(res.text);
   }
@@ -177,8 +175,8 @@ exports.Instrument = class {
     const jsonWhere = JSON.stringify(where);
     //console.log(">>> Instrument.count where", jsonWhere);
     const url = jsonWhere
-      ? baseUrl + "/instruments/count?where=" + jsonWhere
-      : baseUrl + "/instruments/count";
+      ? baseUrl + "/api/v3/instruments/count?where=" + jsonWhere
+      : baseUrl + "/api/v3/instruments/count";
     const res = await superagent.get(url);
     return JSON.parse(res.text);
   }
@@ -195,8 +193,8 @@ exports.Sample = class {
     const jsonFilter = JSON.stringify(filter);
     //console.log(">>> Sample.find filter", jsonFilter);
     const url = jsonFilter
-      ? baseUrl + "/samples?filter=" + jsonFilter
-      : baseUrl + "/samples";
+      ? baseUrl + "/api/v3/samples?filter=" + jsonFilter
+      : baseUrl + "/api/v3/samples";
     const res = await superagent.get(url);
     return JSON.parse(res.text);
   }

--- a/test/dataset.test.js
+++ b/test/dataset.test.js
@@ -99,8 +99,7 @@ describe("Dataset", () => {
           ? (o[nameMap[k] || k] = {}, renameKeys(ds[k], o[nameMap[k] || k]))
           : o[nameMap[k] || k] = ds[k],
         o
-      ),
-      init);
+      ), init);
 
     const testsPhotonEnergy = [
       {
@@ -381,4 +380,48 @@ describe("Dataset", () => {
         });
     });
   });
+
+  describe("GET /datasets/count", () => {
+    context("no filter", () => {
+      it("should return the dataset count", (done) => {
+        request(app)
+          .get(requestUrl + "/count")
+          .set("Accept", "application/json")
+          .expect(200)
+          .expect("Content-Type", /json/)
+          .end((err, res) => {
+            if (err) throw err;
+
+            expect(res.body).to.have.property("count");
+            done();
+          });
+      });
+    });
+
+    context("with filter", () => {
+      it("should return the dataset count", (done) => {
+
+        const filter = JSON.stringify({
+          where: [
+            {
+              "dataSetName": "ProbablyDoesntExist"
+            },
+          ],
+        });
+
+        request(app)
+          .get(requestUrl + "/count" + "?filter=" + filter)
+          .set("Accept", "application/json")
+          .expect(200)
+          .expect("Content-Type", /json/)
+          .end((err, res) => {
+            if (err) throw err;
+
+            expect(res.body).to.have.property("count");
+            done();
+          });
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
## Description

The /api/Datasets/count endpoint currently fetches all datasets and checks the length.

This will give the result 100 if there are >= 100 datasets with no where paramter, that is how the datasets endpoint work if you don't specify a limit.

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
